### PR TITLE
Replace print() with logging in qdot

### DIFF
--- a/qdot/correlators.py
+++ b/qdot/correlators.py
@@ -9,6 +9,7 @@ Serial and parallel implementations are both provided. The parallel version
 uses multiprocessing.Pool.starmap and scales to available CPU cores.
 """
 
+import logging
 import multiprocessing
 import numpy as np
 import qutip
@@ -17,6 +18,8 @@ import scipy.constants as const
 from qdot.isotopes import species_dict
 from qdot.hamiltonians import faraday_hamiltonian
 from qdot.io import load_efg
+
+logger = logging.getLogger(__name__)
 
 
 def spin_correlator(t, nuclear_hamiltonian, spin_axis):
@@ -194,7 +197,7 @@ def run_log_correlator_simulation(data_dir, save_dir, min_time_exp, max_time_exp
             data_dir, timerange, applied_field, species,
             region_bounds, step_size, chunksize,
         )
-        print(f"{species} done.")
+        logger.info("%s done.", species)
 
     archive_name = (
         f"log_time_correlator_data_B{applied_field}T"
@@ -241,7 +244,7 @@ def run_linear_correlator_simulation(data_dir, save_dir, min_time, max_time, tim
             data_dir, timerange, applied_field, species,
             region_bounds, step_size, chunksize,
         )
-        print(f"{species} done.")
+        logger.info("%s done.", species)
 
     archive_name = (
         f"linear_time_correlator_data_B{applied_field}T"

--- a/qdot/io.py
+++ b/qdot/io.py
@@ -14,8 +14,12 @@ EFG archives are saved to / loaded from data_dir using a naming convention
 derived from the species, region bounds, and step size.
 """
 
+import logging
 import pathlib
+
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 def load_sokolov_data(data_dir, region_bounds, step_size=1):
@@ -122,7 +126,7 @@ def save_efg(data_dir, nuclear_species, region_bounds, step_size,
     if path.exists():
         return
     np.savez(path, eta=eta, V_XX=V_XX, V_YY=V_YY, V_ZZ=V_ZZ, euler_angles=euler_angles)
-    print(f"Saved EFG archive: {path}")
+    logger.info("Saved EFG archive: %s", path)
 
 
 def load_efg(data_dir, nuclear_species, region_bounds, step_size=1,


### PR DESCRIPTION
## Summary

- Replaces three `print()` calls in `qdot/io.py` and `qdot/correlators.py` with `logger.info()`
- Each module now has its own `logger = logging.getLogger(__name__)`, following standard Python library conventions
- Callers control verbosity via the normal `logging` configuration — the library no longer writes to stdout unconditionally

## Test plan
- [ ] `pytest tests/` — all 21 tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)