### PR TITLE
Add strain tests and examples; fix scipy x0 dimension bug

### DIFF
--- a/examples/strain_sokolov_data.py
+++ b/examples/strain_sokolov_data.py
@@ -1,0 +1,142 @@
+"""
+Sokolov strain data examples.
+
+Loads and visualises the experimental strain field from the Sokolov dataset:
+    Sokolov et al., Phys. Rev. B 93, 045301 (2016)
+    DOI: 10.1103/PhysRevB.93.045301
+
+Run from the repo root:
+
+    python examples/strain_sokolov_data.py
+
+Required data files
+-------------------
+Set DATA_DIR below to the directory containing:
+    full_epsilon_xx.txt   — ε_xx component, 1600×1600 floats
+    full_epsilon_xy.txt   — ε_xy component, 1600×1600 floats
+    full_epsilon_yy.txt   — ε_yy component, 1600×1600 floats
+
+These files are not included in the repository. Contact the authors of the
+paper or the original researcher for access.
+
+Output
+------
+Three PNG files in claude-test-graphs/ (if data is present):
+    strain_sokolov_full_region.png   — ε_xx, ε_xz, ε_zz across the full dot
+    strain_sokolov_dot_only.png      — same components cropped to the dot
+    strain_sokolov_shear_hist.png    — shear strain distribution in the dot
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import pathlib
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+from matplotlib.colors import Normalize
+
+from qdot.io import load_sokolov_data
+
+# ---------------------------------------------------------------------------
+# Configuration — set this to the directory containing the Sokolov .txt files
+# ---------------------------------------------------------------------------
+DATA_DIR = pathlib.Path("path/to/sokolov/data")
+
+OUTPUT_DIR = pathlib.Path("claude-test-graphs")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+# Two regions used throughout the original analysis.
+# [left, right, top, bottom] in pixel coordinates of the 1600×1600 source.
+FULL_REGION = [100, 1200, 200, 1000]
+DOT_REGION = [100, 1200, 439, 880]
+
+# ---------------------------------------------------------------------------
+# Data availability check
+# ---------------------------------------------------------------------------
+required = [DATA_DIR / f for f in
+            ("full_epsilon_xx.txt", "full_epsilon_xy.txt", "full_epsilon_yy.txt")]
+missing = [p for p in required if not p.exists()]
+if missing:
+    print("Sokolov data files not found. Set DATA_DIR in this script.")
+    print("Missing:")
+    for p in missing:
+        print(f"  {p}")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Load data
+# ---------------------------------------------------------------------------
+print("Loading Sokolov strain data (large files — this may take a moment)...")
+full_xx, full_xz, full_zz = load_sokolov_data(DATA_DIR, FULL_REGION)
+dot_xx, dot_xz, dot_zz = load_sokolov_data(DATA_DIR, DOT_REGION)
+print(f"  full region shape: {full_xx.shape}")
+print(f"  dot region shape:  {dot_xx.shape}")
+
+
+def _strain_map(xx, xz, zz, title, save_path):
+    """Three-panel strain component map matching the Sokolov paper layout."""
+    components = [(xx, r"$\epsilon_{xx}$"), (zz, r"$\epsilon_{zz}$"),
+                  (xz, r"$\epsilon_{xz}$")]
+
+    all_vals = np.concatenate([a.ravel() for a, _ in components])
+    vmin, vmax = np.percentile(all_vals, 2), np.percentile(all_vals, 98)
+
+    cmap = cm.RdBu
+    norm = Normalize(vmin, vmax)
+
+    fig, axs = plt.subplots(1, 3, figsize=(10, 4))
+    for ax, (data, label) in zip(axs, components):
+        ax.imshow(data, cmap=cmap, norm=norm, origin="upper")
+        ax.axis("off")
+        ax.set_title(label, fontsize=14)
+
+    cbar_ax = fig.add_axes([0.15, 0.08, 0.7, 0.04])
+    plt.colorbar(cm.ScalarMappable(norm=norm, cmap=cmap),
+                 cax=cbar_ax, orientation="horizontal", label="Strain")
+    fig.suptitle(title, y=1.01)
+    fig.tight_layout()
+    fig.savefig(save_path, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  saved: {save_path.name}")
+
+
+# ---------------------------------------------------------------------------
+# Graph 1: Full dot region strain map
+# ---------------------------------------------------------------------------
+print("Plotting full region strain map...")
+_strain_map(full_xx, full_xz, full_zz,
+            "Sokolov strain — full region",
+            OUTPUT_DIR / "strain_sokolov_full_region.png")
+
+# ---------------------------------------------------------------------------
+# Graph 2: Dot-only strain map
+# ---------------------------------------------------------------------------
+print("Plotting dot-only strain map...")
+_strain_map(dot_xx, dot_xz, dot_zz,
+            "Sokolov strain — dot region",
+            OUTPUT_DIR / "strain_sokolov_dot_only.png")
+
+# ---------------------------------------------------------------------------
+# Graph 3: Shear strain histogram
+# ---------------------------------------------------------------------------
+print("Plotting shear strain histogram...")
+fig, ax = plt.subplots(figsize=(8, 5))
+
+# The Sokolov paper distinguishes ε_xz as measured from the symmetric
+# shear strain 2|ε_xz|.
+ax.hist(dot_xz.ravel(), bins="auto", histtype="step", density=True,
+        label=r"$\epsilon_{xz}$ (as measured)")
+ax.hist(2 * np.abs(dot_xz).ravel(), bins="auto", histtype="step", density=True,
+        label=r"$2|\epsilon_{xz}|$ (symmetric shear)")
+ax.set_xlabel("Shear strain")
+ax.set_ylabel("Probability density")
+ax.set_title("Shear strain distribution in dot region")
+ax.legend()
+fig.tight_layout()
+fig.savefig(OUTPUT_DIR / "strain_sokolov_shear_hist.png")
+plt.close(fig)
+print("  saved: strain_sokolov_shear_hist.png")
+
+print(f"\nAll graphs saved to {OUTPUT_DIR.resolve()}")

--- a/examples/strain_toy_model.py
+++ b/examples/strain_toy_model.py
@@ -1,0 +1,81 @@
+"""
+Strain toy model examples.
+
+Demonstrates the spring-mass strain model from qdot.strain across three
+lattice configurations. Run from the repo root:
+
+    python examples/strain_toy_model.py
+
+Output: six PNG files in claude-test-graphs/
+
+Physics background
+------------------
+The model places atoms on a 2D grid connected by springs. Each bond has a
+species-dependent stiffness (from Vurgaftman 2001) and natural length. When
+Indium replaces Gallium its natural bond length to As is 6% longer (1.06 vs
+1.00), so the surrounding lattice is forced to stretch — this is the origin of
+the strain field around an InAs inclusion in GaAs.
+
+scipy.optimize.minimize finds the lowest-energy atomic positions, then
+qdot.strain.strain_tensor computes the symmetric Cauchy–Green strain tensor at
+each site from the deformation gradient.
+
+Three scenarios
+---------------
+1. Pure GaAs      — baseline; strain should be negligible everywhere.
+2. Single In atom — local radial distortion around the In site.
+3. 5×5 In block   — strong interface strain where InAs meets GaAs.
+"""
+
+import matplotlib
+matplotlib.use("Agg")
+
+import pathlib
+import numpy as np
+
+from qdot.strain import run_strain_simulation, strain_tensor, block_in_positions
+from qdot.plot import plot_strain_lattice, plot_strain_tensors
+
+OUTPUT_DIR = pathlib.Path("claude-test-graphs")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+# 15×15 gives good visual resolution in a few seconds.
+N = 15
+
+
+def run_and_save(label, lattice_type, in_positions=None):
+    print(f"Running: {label}...")
+    species, unstrained, strained, t, row_err, col_err = run_strain_simulation(
+        N, N, lattice_type=lattice_type, in_positions=in_positions or []
+    )
+    tensors = strain_tensor(strained, unstrained)
+
+    lattice_path = OUTPUT_DIR / f"strain_toy_{label}_lattice.png"
+    tensor_path = OUTPUT_DIR / f"strain_toy_{label}_tensor.png"
+
+    plot_strain_lattice(species, unstrained, strained, real_atoms=True,
+                        save_path=lattice_path)
+    plot_strain_tensors(tensors, save_path=tensor_path)
+
+    print(f"  minimisation: {t}s  |  row error: {row_err}%  |  col error: {col_err}%")
+    print(f"  strain range: [{tensors.min():.4f}, {tensors.max():.4f}]")
+    print(f"  saved: {lattice_path.name}, {tensor_path.name}")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Pure GaAs — no Indium, no strain
+# ---------------------------------------------------------------------------
+run_and_save("gaas", lattice_type=0)
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Single In atom at the lattice centre
+# ---------------------------------------------------------------------------
+run_and_save("single_in", lattice_type=1)
+
+# ---------------------------------------------------------------------------
+# Scenario 3: 5×5 block of In atoms centred in the lattice
+# ---------------------------------------------------------------------------
+in_pos = block_in_positions([5, 5], [10, 10])
+run_and_save("in_block", lattice_type=2, in_positions=in_pos)
+
+print(f"\nAll graphs saved to {OUTPUT_DIR.resolve()}")

--- a/qdot/strain.py
+++ b/qdot/strain.py
@@ -287,7 +287,7 @@ def run_strain_simulation(n_rows, n_cols, lattice_type=0,
 
     t0 = time.time()
     result = opt.minimize(
-        _potential_energy, unstr,
+        _potential_energy, unstr.flatten(),
         args=(spring_k, natural_l, box_w, box_h, n_rows, n_cols),
     )
     t1 = time.time()

--- a/tests/test_strain.py
+++ b/tests/test_strain.py
@@ -1,0 +1,189 @@
+"""
+Tests for qdot.strain.
+
+Physical invariants verified:
+- Pure GaAs has zero strain: all Ga-As bonds have equal natural length (1.0),
+  so the uniform grid is already the minimum-energy state.
+- Strain tensor is symmetric (ε_ij = ε_ji): enforced by the 0.5*(F + Fᵀ)
+  formula, but worth pinning explicitly.
+- Identical strained and unstrained coords → zero strain.
+- A single In atom introduces strain (In-As natural length is 1.06 vs 1.00).
+- More In substitutions produce a larger peak strain than a single atom.
+"""
+
+import math
+import numpy as np
+import pytest
+
+from qdot.strain import (
+    block_in_positions,
+    gaas_lattice,
+    gaas_lattice_with_indium,
+    gaas_lattice_with_indium_centre,
+    run_strain_simulation,
+    strain_tensor,
+    unstrained_positions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lattice generators
+# ---------------------------------------------------------------------------
+
+class TestLatticeGenerators:
+    def test_gaas_lattice_shapes(self):
+        large, small = gaas_lattice(5, 7)
+        assert small.shape == (5, 7)
+        assert large.shape == (7, 9)
+
+    def test_gaas_lattice_only_ga_and_as(self):
+        _, small = gaas_lattice(6, 6)
+        assert set(small.flatten()).issubset({0, 1})
+
+    def test_gaas_lattice_alternates(self):
+        """Every pair of adjacent atoms should be different species."""
+        _, small = gaas_lattice(6, 6)
+        assert np.all(small[:-1, :] != small[1:, :]), "vertical neighbours not alternating"
+        assert np.all(small[:, :-1] != small[:, 1:]), "horizontal neighbours not alternating"
+
+    def test_indium_centre_exactly_one_in(self):
+        _, small = gaas_lattice_with_indium_centre(7, 7)
+        assert np.sum(small == 2) == 1
+
+    def test_indium_centre_at_centre(self):
+        n = 7
+        _, small = gaas_lattice_with_indium_centre(n, n)
+        (r, c) = np.argwhere(small == 2)[0]
+        # must be within one site of the geometric centre
+        assert abs(r - n // 2) <= 1
+        assert abs(c - n // 2) <= 1
+
+    def test_indium_centre_replaces_ga_not_as(self):
+        """In can only replace Ga (species 0), not As (species 1)."""
+        n = 7
+        _, gaas = gaas_lattice(n, n)
+        _, with_in = gaas_lattice_with_indium_centre(n, n)
+        (r, c) = np.argwhere(with_in == 2)[0]
+        assert gaas[r, c] == 0, "In was placed on an As site"
+
+    def test_block_in_positions_count(self):
+        pos = block_in_positions([2, 2], [5, 5])
+        assert len(pos) == 9  # 3×3
+
+    def test_block_in_positions_range(self):
+        pos = block_in_positions([1, 3], [4, 6])
+        xs = [p[0] for p in pos]
+        ys = [p[1] for p in pos]
+        assert min(xs) == 1 and max(xs) == 3
+        assert min(ys) == 3 and max(ys) == 5
+
+
+# ---------------------------------------------------------------------------
+# Unstrained positions
+# ---------------------------------------------------------------------------
+
+class TestUnstrainedPositions:
+    def test_shape(self):
+        coords = unstrained_positions(5, 7)
+        assert coords.shape == (5, 7, 2)
+
+    def test_uniform_row_spacing(self):
+        coords = unstrained_positions(6, 6)
+        dy = np.diff(coords[:, 0, 1])
+        assert np.allclose(dy, dy[0], rtol=1e-10)
+
+    def test_uniform_col_spacing(self):
+        coords = unstrained_positions(6, 6)
+        dx = np.diff(coords[0, :, 0])
+        assert np.allclose(dx, dx[0], rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Strain tensor
+# ---------------------------------------------------------------------------
+
+class TestStrainTensor:
+    def test_output_shape(self):
+        coords = unstrained_positions(5, 7)
+        tensors = strain_tensor(coords, coords)
+        assert tensors.shape == (5, 7, 2, 2)
+
+    def test_identical_coords_zero_strain(self):
+        """No displacement → no strain. Tests the deformation gradient formula directly."""
+        coords = unstrained_positions(6, 6)
+        tensors = strain_tensor(coords, coords)
+        assert np.allclose(tensors, 0, atol=1e-10)
+
+    def test_symmetry_pure_gaas(self):
+        """ε_01 == ε_10 for pure GaAs."""
+        _, unstrained, strained, *_ = run_strain_simulation(5, 5, lattice_type=0)
+        tensors = strain_tensor(strained, unstrained)
+        assert np.allclose(tensors[:, :, 0, 1], tensors[:, :, 1, 0], atol=1e-10)
+
+    def test_symmetry_with_indium(self):
+        """ε_01 == ε_10 holds for strained lattice too."""
+        _, unstrained, strained, *_ = run_strain_simulation(7, 7, lattice_type=1)
+        tensors = strain_tensor(strained, unstrained)
+        assert np.allclose(tensors[:, :, 0, 1], tensors[:, :, 1, 0], atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Full simulation
+# ---------------------------------------------------------------------------
+
+class TestRunStrainSimulation:
+    def test_return_shapes(self):
+        n = 7
+        species, unstrained, strained, t, _, _ = run_strain_simulation(n, n, lattice_type=0)
+        assert species.shape == (n, n)
+        assert unstrained.shape == (n, n, 2)
+        assert strained.shape == (n, n, 2)
+        assert isinstance(t, float)
+
+    def test_pure_gaas_zero_strain(self):
+        """
+        Pure GaAs: all Ga-As bonds share the same natural length (1.0) and the
+        uniform grid already minimises the energy. The optimizer should leave
+        positions unchanged, giving zero strain everywhere.
+        """
+        _, unstrained, strained, *_ = run_strain_simulation(5, 5, lattice_type=0)
+        tensors = strain_tensor(strained, unstrained)
+        assert np.allclose(tensors, 0, atol=1e-6)
+
+    def test_pure_gaas_row_col_error_zero(self):
+        *_, avg_row_diff, avg_col_diff = run_strain_simulation(5, 5, lattice_type=0)
+        assert avg_row_diff == pytest.approx(0.0, abs=1e-3)
+        assert avg_col_diff == pytest.approx(0.0, abs=1e-3)
+
+    def test_pure_gaas_strained_equals_unstrained(self):
+        _, unstrained, strained, *_ = run_strain_simulation(5, 5, lattice_type=0)
+        assert np.allclose(strained, unstrained, atol=1e-6)
+
+    def test_single_in_distorts_lattice(self):
+        """In-As natural length is 1.06, so the In site must push neighbours out."""
+        _, unstrained, strained, *_ = run_strain_simulation(7, 7, lattice_type=1)
+        assert not np.allclose(strained, unstrained, atol=1e-4)
+
+    def test_single_in_nonzero_strain(self):
+        _, unstrained, strained, *_ = run_strain_simulation(7, 7, lattice_type=1)
+        tensors = strain_tensor(strained, unstrained)
+        assert np.max(np.abs(tensors)) > 1e-4
+
+    def test_in_block_more_strain_than_single_in(self):
+        """
+        A 3×3 In block contains more Indium than a single atom and should
+        produce a larger peak strain.
+        """
+        _, u1, s1, *_ = run_strain_simulation(9, 9, lattice_type=1)
+        peak_single = np.max(np.abs(strain_tensor(s1, u1)))
+
+        in_pos = block_in_positions([3, 3], [6, 6])
+        _, u2, s2, *_ = run_strain_simulation(9, 9, lattice_type=2, in_positions=in_pos)
+        peak_block = np.max(np.abs(strain_tensor(s2, u2)))
+
+        assert peak_block > peak_single
+
+    def test_in_block_species_contains_indium(self):
+        in_pos = block_in_positions([2, 2], [5, 5])
+        species, *_ = run_strain_simulation(9, 9, lattice_type=2, in_positions=in_pos)
+        assert np.any(species == 2), "No Indium found in species array"


### PR DESCRIPTION
## Summary

- **Bug fix** (`qdot/strain.py`): `scipy.optimize.minimize` requires `x0` to be 1D from scipy 1.11+. The code was passing the raw `(n_rows, n_cols, 2)` positions array, which raised `ValueError: 'x0' must only have one dimension`. Fixed by calling `.flatten()` before passing — the energy function already reshapes internally. This was the breakage that caused the original `scipy<1.11` pin.

- **Tests** (`tests/test_strain.py`): 23 tests across four classes:
  - `TestLatticeGenerators` — species distributions, alternating structure, In placement rules
  - `TestUnstrainedPositions` — shape, uniform row/column spacing
  - `TestStrainTensor` — symmetry (`ε_ij = ε_ji`), zero strain for identical inputs, output shape
  - `TestRunStrainSimulation` — zero strain for pure GaAs (key physical invariant), single In introduces strain, In block produces more peak strain than single In

- **Examples** (`examples/`):
  - `strain_toy_model.py` — runs three scenarios (pure GaAs, single In, 5×5 In block), saves 6 PNGs to `claude-test-graphs/`
  - `strain_sokolov_data.py` — loads and plots Sokolov experimental strain data; exits cleanly with an informative message if the data files are not present

## Test plan
- [ ] `pytest tests/` — all 44 tests pass
- [ ] `python examples/strain_toy_model.py` — produces 6 graphs in `claude-test-graphs/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)