### PR TITLE
Add vectorised calculate_efg (~17× speedup)

### DIFF
--- a/benchmarks/run_efg.py
+++ b/benchmarks/run_efg.py
@@ -1,22 +1,18 @@
 """
-Benchmark the current calculate_efg implementation.
+Benchmark calculate_efg vs calculate_efg_vectorised.
 
 Generates synthetic strain arrays at several grid sizes matching the scale of
 the real Sokolov dataset (full dot region: 441×1100 ≈ 485,000 sites) and
-measures execution time per size.
+measures execution time per size for both implementations.
 
 Run from the repo root:
     python -m benchmarks.run_efg
-
-The Sokolov dot region at step_size=1 is far too large to run many times with
-the current implementation, so smaller sizes are timed properly (multiple
-runs) and a single large run is used to project to real-world scale.
 """
 
 import numpy as np
 
-from qdot.efg import calculate_efg
-from benchmarks.timing import benchmark, print_result, _fmt
+from qdot.efg import calculate_efg, calculate_efg_vectorised
+from benchmarks.timing import benchmark, compare, print_result, _fmt
 
 # Synthetic strain values representative of the Sokolov dataset.
 # Real data: ε_xx and ε_zz in [-0.02, 0.02], ε_xz in [-0.01, 0.01].
@@ -29,8 +25,6 @@ def make_strain(shape):
     return xx, xz, zz
 
 
-# Sizes benchmarked with multiple runs.
-# 200×200 = 40,000 sites is feasible; beyond that the loop takes minutes.
 TIMED_SIZES = [
     (10,  10),
     (50,  50),
@@ -38,7 +32,6 @@ TIMED_SIZES = [
     (200, 200),
 ]
 
-# One larger single-run measurement to anchor a projection to real scale.
 PROJECTION_SIZE = (400, 400)
 
 SPECIES   = "Ga69"
@@ -48,62 +41,76 @@ WARMUP    = 1
 # ---------------------------------------------------------------------------
 
 print()
-print("calculate_efg  —  current implementation")
-print("=" * 55)
+print("calculate_efg  —  scalar vs vectorised")
+print("=" * 60)
 print(f"species: {SPECIES}   runs per size: {N_RUNS}  warmup: {WARMUP}")
 print()
 
-results = {}
+scalar_results = {}
+vector_results = {}
+
 for n, m in TIMED_SIZES:
     xx, xz, zz = make_strain((n, m))
-    r = benchmark(
-        f"calculate_efg  {n}×{m}",
+
+    r_s = benchmark(
+        f"scalar      {n}×{m}",
         calculate_efg,
         SPECIES, xx, xz, zz,
-        n_runs=N_RUNS,
-        warmup=WARMUP,
-        n_sites=n * m,
+        n_runs=N_RUNS, warmup=WARMUP, n_sites=n * m,
     )
-    results[(n, m)] = r
-    print_result(r)
+    r_v = benchmark(
+        f"vectorised  {n}×{m}",
+        calculate_efg_vectorised,
+        SPECIES, xx, xz, zz,
+        n_runs=N_RUNS, warmup=WARMUP, n_sites=n * m,
+    )
+    scalar_results[(n, m)] = r_s
+    vector_results[(n, m)] = r_v
+
+    print_result(r_s)
+    print_result(r_v)
+    compare(r_s, r_v)
     print()
 
 # ---------------------------------------------------------------------------
-# Single large run — not warmed up, results flagged as approximate.
+# Single large run for both — unwarmed.
 
 print(f"Large single run  {PROJECTION_SIZE[0]}×{PROJECTION_SIZE[1]}  (no warmup — approximate)")
-print("-" * 55)
+print("-" * 60)
 n, m = PROJECTION_SIZE
 xx, xz, zz = make_strain((n, m))
-r_large = benchmark(
-    f"calculate_efg  {n}×{m}",
-    calculate_efg,
-    SPECIES, xx, xz, zz,
-    n_runs=1,
-    warmup=0,
-    n_sites=n * m,
+
+r_s_large = benchmark(
+    f"scalar      {n}×{m}",
+    calculate_efg, SPECIES, xx, xz, zz,
+    n_runs=1, warmup=0, n_sites=n * m,
 )
-print(f"  time:     {_fmt(r_large.mean)}")
-print(f"  per site: {_fmt(r_large.per_site)}  ({r_large.n_sites:,} sites)")
+r_v_large = benchmark(
+    f"vectorised  {n}×{m}",
+    calculate_efg_vectorised, SPECIES, xx, xz, zz,
+    n_runs=1, warmup=0, n_sites=n * m,
+)
+
+print(f"  scalar      time: {_fmt(r_s_large.mean)}   per site: {_fmt(r_s_large.per_site)}")
+print(f"  vectorised  time: {_fmt(r_v_large.mean)}   per site: {_fmt(r_v_large.per_site)}")
+print(f"  speedup:    {r_s_large.mean / r_v_large.mean:.1f}×")
 print()
 
 # ---------------------------------------------------------------------------
 # Projection to full Sokolov dataset scale.
 
-dot_sites    = 441 * 1100   # step_size=1, full dot region
-fine_sites   = 441 * 1100   # same, shown for clarity
-per_site_s   = r_large.per_site
+dot_sites = 441 * 1100
+s_per   = r_s_large.per_site
+v_per   = r_v_large.per_site
 
-print("Projections  (based on large single-run per-site time)")
-print("-" * 55)
+print("Projections to real dataset  (based on 400×400 per-site time)")
+print("-" * 60)
 for label, sites in [
     ("dot region  step=1  (441×1100)", dot_sites),
-    ("dot region  step=5  (88×220)",  dot_sites // 25),
-    ("dot region  step=10 (44×110)",  dot_sites // 100),
+    ("dot region  step=5  (88×220)",   dot_sites // 25),
+    ("dot region  step=10 (44×110)",   dot_sites // 100),
 ]:
-    projected = per_site_s * sites
-    print(f"  {label:<38}  {_fmt(projected)}  ({sites:,} sites)")
-
-print()
-print("Note: projections assume linear scaling, which holds for the loop-based")
-print("implementation since each site is processed independently.")
+    print(f"  {label}")
+    print(f"    scalar:      {_fmt(s_per * sites)}  ({sites:,} sites)")
+    print(f"    vectorised:  {_fmt(v_per * sites)}")
+    print(f"    speedup:     {s_per / v_per:.1f}×")

--- a/qdot/efg.py
+++ b/qdot/efg.py
@@ -102,3 +102,146 @@ def calculate_efg(nuclear_species, xx_array, xz_array, zz_array, use_sundfors=Fa
             euler_angles[i, j] = euler_angles_from_rot_mat(rot_mat)
 
     return eta, V_XX, V_YY, V_ZZ, euler_angles
+
+
+def calculate_efg_vectorised(
+    nuclear_species: str,
+    xx_array: np.ndarray,
+    xz_array: np.ndarray,
+    zz_array: np.ndarray,
+    use_sundfors: bool = False,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Vectorised EFG tensor calculation — identical interface to calculate_efg.
+
+    Replaces the per-site Python loop with batched NumPy operations:
+
+      1. All (n × m) EFG tensors are constructed in one pass via array slicing
+         (no loop, pure element-wise arithmetic).
+      2. np.linalg.eigh processes the entire (n, m, 3, 3) stack in one BLAS call.
+         eigh exploits the matrix symmetry — faster and numerically better than
+         the general eig used in calculate_efg for real symmetric matrices.
+      3. Eigenvalue sorting uses argsort on the last axis with take_along_axis
+         to simultaneously reorder both eigenvalues and eigenvector columns.
+      4. Euler angles are extracted with np.where chains instead of per-site
+         branches, including the gimbal-lock case (rot[2,0] == ±1).
+
+    The eigenvalues (V_XX, V_YY, V_ZZ) and η are numerically equivalent to
+    calculate_efg. The Euler angles describe the same physical rotations but
+    may differ in sign from the scalar version because eigh and eig can return
+    eigenvectors with different sign conventions.
+
+    Args:
+        nuclear_species (str): One of "Ga69", "Ga71", "As75", "In115".
+        xx_array (ndarray): ε_xx strain component, shape (n, m).
+        xz_array (ndarray): ε_xz strain component, shape (n, m).
+        zz_array (ndarray): ε_zz strain component, shape (n, m).
+        use_sundfors (bool): Use Sundfors (1974) parameters if True.
+
+    Returns:
+        eta, V_XX, V_YY, V_ZZ (ndarray): shape (n, m).
+        euler_angles (ndarray): shape (n, m, 3).
+    """
+    params = old_species_dict if use_sundfors else species_dict
+    species = params[nuclear_species]
+
+    S11 = species["S11"]
+    S12 = -S11 / 2
+    S44 = species["S44"]
+
+    n, m = xx_array.shape
+    xx, xz, zz = xx_array, xz_array, zz_array
+
+    # ------------------------------------------------------------------
+    # Step 1 — build all EFG tensors at once.
+    #
+    # V is real symmetric. The unique elements are:
+    #   V[0,0] = S12*(zz - xx)
+    #   V[1,1] = (S12+S11)*xx + S12*zz
+    #   V[2,2] = 2*S12*xx + S11*zz
+    #   V[0,2] = V[2,0] = V[1,2] = V[2,1] = S44*xz
+    #   V[0,1] = V[1,0] = 0
+    # ------------------------------------------------------------------
+    V = np.zeros((n, m, 3, 3))
+    V[:, :, 0, 0] = S12 * (zz - xx)
+    V[:, :, 1, 1] = (S12 + S11) * xx + S12 * zz
+    V[:, :, 2, 2] = 2 * S12 * xx + S11 * zz
+    V[:, :, 0, 2] = S44 * xz
+    V[:, :, 2, 0] = S44 * xz
+    V[:, :, 1, 2] = S44 * xz
+    V[:, :, 2, 1] = S44 * xz
+
+    # ------------------------------------------------------------------
+    # Step 2 — batched eigendecomposition.
+    #
+    # eigh input:  (n, m, 3, 3)
+    # w output:    (n, m, 3)    eigenvalues, ascending algebraic order
+    # v output:    (n, m, 3, 3) v[i,j,:,k] is the k-th eigenvector at (i,j)
+    # ------------------------------------------------------------------
+    w, v = np.linalg.eigh(V)
+
+    # ------------------------------------------------------------------
+    # Step 3 — sort by descending |eigenvalue|: V_ZZ ≥ V_YY ≥ V_XX.
+    # ------------------------------------------------------------------
+    sort_idx = np.argsort(np.abs(w), axis=-1)[:, :, ::-1]     # (n, m, 3)
+
+    w_sorted  = np.take_along_axis(w, sort_idx, axis=-1)
+    V_ZZ = w_sorted[:, :, 0]
+    V_YY = w_sorted[:, :, 1]
+    V_XX = w_sorted[:, :, 2]
+
+    # Reorder eigenvector columns to match the sorted eigenvalues.
+    # Broadcasting sort_idx from (n,m,3) → (n,m,3,3) applies the same
+    # column permutation to every row of the eigenvector matrix.
+    sort_idx_v = np.broadcast_to(sort_idx[:, :, np.newaxis, :], (n, m, 3, 3))
+    v_sorted = np.take_along_axis(v, sort_idx_v, axis=-1)      # (n, m, 3, 3)
+    # v_sorted[:,:,:, 0] = V_ZZ eigenvector at every site
+    # v_sorted[:,:,:, 1] = V_YY eigenvector at every site
+    # v_sorted[:,:,:, 2] = V_XX eigenvector at every site
+
+    # ------------------------------------------------------------------
+    # Step 4 — biaxiality η = (V_XX − V_YY) / V_ZZ.
+    # Undefined where V_ZZ = 0 (no strain → no EFG).
+    # ------------------------------------------------------------------
+    eta = np.where(V_ZZ != 0, (V_XX - V_YY) / V_ZZ, np.nan)
+
+    # ------------------------------------------------------------------
+    # Step 5 — assemble rotation matrices.
+    #
+    # Columns: [V_XX eigvec | V_YY eigvec | V_ZZ eigvec]
+    # Matches the scalar:  rot = np.array([v[:,idx[2]], v[:,idx[1]], v[:,idx[0]]]).T
+    # ------------------------------------------------------------------
+    rot = np.stack([
+        v_sorted[:, :, :, 2],   # V_XX eigenvector → column 0
+        v_sorted[:, :, :, 1],   # V_YY eigenvector → column 1
+        v_sorted[:, :, :, 0],   # V_ZZ eigenvector → column 2
+    ], axis=-1)                  # (n, m, 3, 3)
+
+    # ------------------------------------------------------------------
+    # Step 6 — vectorised Euler angle extraction (X-Y-Z, Slabaugh 2008).
+    #
+    # Gimbal lock: rot[:,:,2,0] == ±1 → cos(beta) = 0, handled by np.where.
+    # np.where evaluates both branches everywhere and selects; safe_cos
+    # prevents division-by-zero in the normal-case expressions at gimbal sites.
+    # ------------------------------------------------------------------
+    r20    = rot[:, :, 2, 0]
+    gimbal = np.abs(r20) >= 1.0
+
+    beta_normal  = -np.arcsin(np.clip(r20, -1.0, 1.0))
+    cos_beta     = np.cos(beta_normal)
+    safe_cos     = np.where(np.abs(cos_beta) > 1e-10, cos_beta, 1.0)
+
+    alpha_normal = np.arctan2(rot[:, :, 2, 1] / safe_cos, rot[:, :, 2, 2] / safe_cos)
+    gamma_normal = np.arctan2(rot[:, :, 1, 0] / safe_cos, rot[:, :, 0, 0] / safe_cos)
+
+    # Gimbal lock sub-cases (gamma is fixed to 0 in both).
+    alpha_neg = np.arctan2( rot[:, :, 0, 1],  rot[:, :, 0, 2])   # r20 == -1
+    alpha_pos = np.arctan2(-rot[:, :, 0, 1], -rot[:, :, 0, 2])   # r20 == +1
+
+    beta  = np.where(gimbal, np.where(r20 < 0, np.pi / 2, -np.pi / 2), beta_normal)
+    alpha = np.where(gimbal, np.where(r20 < 0, alpha_neg,  alpha_pos),  alpha_normal)
+    gamma = np.where(gimbal, 0.0, gamma_normal)
+
+    euler_angles = np.stack([alpha, beta, gamma], axis=-1)         # (n, m, 3)
+
+    return eta, V_XX, V_YY, V_ZZ, euler_angles

--- a/tests/test_efg.py
+++ b/tests/test_efg.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from qdot.efg import euler_angles_from_rot_mat, calculate_efg
+from qdot.efg import euler_angles_from_rot_mat, calculate_efg, calculate_efg_vectorised
 
 
 def test_euler_angles_identity():
@@ -50,3 +50,119 @@ def test_calculate_efg_sundfors_gives_different_result():
     _, _, _, V_ZZ_new, _ = calculate_efg("Ga69", xx, xz, zz, use_sundfors=False)
     _, _, _, V_ZZ_old, _ = calculate_efg("Ga69", xx, xz, zz, use_sundfors=True)
     assert not np.allclose(V_ZZ_new, V_ZZ_old)
+
+
+# ---------------------------------------------------------------------------
+# Vectorised implementation
+# ---------------------------------------------------------------------------
+
+def _make_strain(shape, seed=0):
+    rng = np.random.default_rng(seed)
+    xx = rng.uniform(-0.02,  0.02, shape)
+    xz = rng.uniform(-0.01,  0.01, shape)
+    zz = rng.uniform(-0.02,  0.02, shape)
+    return xx, xz, zz
+
+
+
+
+class TestVectorisedEFG:
+    def test_output_shapes_match_scalar(self):
+        n, m = 5, 7
+        xx, xz, zz = _make_strain((n, m))
+        eta_v, vxx_v, vyy_v, vzz_v, euler_v = calculate_efg_vectorised("Ga69", xx, xz, zz)
+        assert eta_v.shape   == (n, m)
+        assert vxx_v.shape   == (n, m)
+        assert vyy_v.shape   == (n, m)
+        assert vzz_v.shape   == (n, m)
+        assert euler_v.shape == (n, m, 3)
+
+    def test_eigenvalues_match_scalar(self):
+        """V_ZZ, V_YY, V_XX from the vectorised version must equal the scalar version."""
+        xx, xz, zz = _make_strain((20, 25))
+        for species in ["Ga69", "Ga71", "As75", "In115"]:
+            _, vxx_s, vyy_s, vzz_s, _ = calculate_efg(species, xx, xz, zz)
+            _, vxx_v, vyy_v, vzz_v, _ = calculate_efg_vectorised(species, xx, xz, zz)
+            np.testing.assert_allclose(vzz_v, vzz_s, rtol=1e-10,
+                                       err_msg=f"{species}: V_ZZ mismatch")
+            np.testing.assert_allclose(vyy_v, vyy_s, rtol=1e-10,
+                                       err_msg=f"{species}: V_YY mismatch")
+            np.testing.assert_allclose(vxx_v, vxx_s, rtol=1e-10,
+                                       err_msg=f"{species}: V_XX mismatch")
+
+    def test_eta_matches_scalar(self):
+        xx, xz, zz = _make_strain((15, 15))
+        eta_s, *_ = calculate_efg("As75", xx, xz, zz)
+        eta_v, *_ = calculate_efg_vectorised("As75", xx, xz, zz)
+        np.testing.assert_allclose(eta_v, eta_s, rtol=1e-10)
+
+    def test_zero_strain_gives_zero_efg(self):
+        n, m = 4, 4
+        zeros = np.zeros((n, m))
+        eta, V_XX, V_YY, V_ZZ, _ = calculate_efg_vectorised("Ga69", zeros, zeros, zeros)
+        np.testing.assert_allclose(V_ZZ, 0.0, atol=1e-25)
+        np.testing.assert_allclose(V_XX, 0.0, atol=1e-25)
+        np.testing.assert_allclose(V_YY, 0.0, atol=1e-25)
+
+    def test_biaxiality_definition(self):
+        xx, xz, zz = _make_strain((6, 6))
+        eta, V_XX, V_YY, V_ZZ, _ = calculate_efg_vectorised("In115", xx, xz, zz)
+        np.testing.assert_allclose(eta, (V_XX - V_YY) / V_ZZ, atol=1e-10)
+
+    def test_sundfors_gives_different_result(self):
+        xx, xz, zz = _make_strain((3, 3))
+        _, _, _, vzz_new, _ = calculate_efg_vectorised("Ga69", xx, xz, zz, use_sundfors=False)
+        _, _, _, vzz_old, _ = calculate_efg_vectorised("Ga69", xx, xz, zz, use_sundfors=True)
+        assert not np.allclose(vzz_new, vzz_old)
+
+    def test_euler_angles_self_consistent(self):
+        """
+        The vectorised Euler extraction must be consistent with the scalar
+        euler_angles_from_rot_mat when both operate on the same rotation matrix.
+
+        The test rebuilds the batch rotation matrices from eigh exactly as
+        calculate_efg_vectorised does, then applies euler_angles_from_rot_mat
+        site by site and compares to the vectorised output.
+
+        Note on det(rot_mat): np.linalg.eig and eigh return eigenvectors with
+        arbitrary signs, so the assembled rotation matrix can have det = ±1.
+        This is a pre-existing property of the scalar implementation.  The test
+        verifies vectorised consistency, not the sign convention.
+        """
+        from qdot.efg import euler_angles_from_rot_mat
+        from qdot.isotopes import species_dict as sd
+
+        n, m = 8, 8
+        xx, xz, zz = _make_strain((n, m))
+
+        S11 = sd["Ga69"]["S11"]
+        S12 = -S11 / 2
+        S44 = sd["Ga69"]["S44"]
+
+        # Rebuild exactly what calculate_efg_vectorised builds internally.
+        V = np.zeros((n, m, 3, 3))
+        V[:, :, 0, 0] = S12 * (zz - xx)
+        V[:, :, 1, 1] = (S12 + S11) * xx + S12 * zz
+        V[:, :, 2, 2] = 2 * S12 * xx + S11 * zz
+        V[:, :, 0, 2] = S44 * xz
+        V[:, :, 2, 0] = S44 * xz
+        V[:, :, 1, 2] = S44 * xz
+        V[:, :, 2, 1] = S44 * xz
+
+        w, v = np.linalg.eigh(V)
+        sort_idx = np.argsort(np.abs(w), axis=-1)[:, :, ::-1]
+        sort_idx_v = np.broadcast_to(sort_idx[:, :, np.newaxis, :], (n, m, 3, 3))
+        v_sorted = np.take_along_axis(v, sort_idx_v, axis=-1)
+        rot = np.stack([v_sorted[:, :, :, 2],
+                        v_sorted[:, :, :, 1],
+                        v_sorted[:, :, :, 0]], axis=-1)
+
+        _, _, _, _, euler_v = calculate_efg_vectorised("Ga69", xx, xz, zz)
+
+        for i in range(n):
+            for j in range(m):
+                expected = euler_angles_from_rot_mat(rot[i, j])
+                np.testing.assert_allclose(
+                    euler_v[i, j], expected, atol=1e-10,
+                    err_msg=f"Euler angle mismatch at site ({i},{j})"
+                )


### PR DESCRIPTION
## Summary

Adds `calculate_efg_vectorised` alongside the original `calculate_efg` in `qdot/efg.py`. The original is unchanged.

**What changed internally:**

| Step | Scalar | Vectorised |
|------|--------|-----------|
| EFG tensor construction | per-site scalar ops in loop | 7 array assignments, no loop |
| Eigendecomposition | `n×m` calls to `eig` (general solver) | one batched `eigh` call (symmetric solver) |
| Eigenvalue sort | per-site `argsort` | single `argsort` over last axis |
| η | per-site division | one `np.where` |
| Euler angles | per-site branches | `np.where` chains |

**Benchmark results (Ga69, Apple Silicon M-series):**

| Grid | Sites | Scalar | Vectorised | Speedup |
|------|-------|--------|-----------|---------|
| 10×10 | 100 | 1.67 ms | 149 µs | 11× |
| 50×50 | 2,500 | 41 ms | 2.4 ms | 17× |
| 100×100 | 10,000 | 166 ms | 9.9 ms | 17× |
| 200×200 | 40,000 | 675 ms | 40 ms | 17× |
| 400×400 | 160,000 | 2.66 s | 163 ms | 16× |

Projected for full Sokolov dot region at step=1 (441×1100, ~485k sites): **8.1 s → 493 ms**.

**Tests:** 7 new tests in `TestVectorisedEFG` — eigenvalues match scalar to rtol=1e-10 for all four species, η matches, Euler angles are self-consistent with `euler_angles_from_rot_mat`.

Note: `np.linalg.eigh` returns eigenvectors with arbitrary signs, so the rotation matrix assembled from eigenvectors can have det = ±1. This is a pre-existing property of the scalar code (which uses `eig`) — not introduced here.

## Test plan
- [ ] `pytest tests/` — all 51 tests pass
- [ ] `python -m benchmarks.run_efg` — shows ~17× speedup

🤖 Generated with [Claude Code](https://claude.ai/claude-code)