### PR TITLE
Add NFF polarisation example

### DIFF
--- a/examples/nff_polarisation.py
+++ b/examples/nff_polarisation.py
@@ -1,9 +1,22 @@
-import matplotlib
-matplotlib.use("Agg")
+"""
+Nuclear Frequency Focussing (NFF) polarisation curves.
 
-import numpy as np
+Two panels:
+  Left  — z-polarisation vs dephasing strength γ for three pulse phases.
+           γ=1 is no dephasing; γ=0.5 is maximum dephasing.
+  Right — z-polarisation in the zero-dephasing limit as the pulse phase
+           sweeps 0 → 2π.
+
+Output: examples/output/nff_polarisation.png
+"""
+
+import pathlib
+
+import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-import os
+import numpy as np
 
 from qdot.nff import dephasing_polarisation_curve, non_dephased_polarisation
 
@@ -36,6 +49,6 @@ ax_right.set_xticklabels(["0", r"$\pi/2$", r"$\pi$", r"$3\pi/2$", r"$2\pi$"])
 
 plt.tight_layout()
 
-output_dir = os.path.join(os.path.dirname(__file__), "..", "claude-test-graphs")
-os.makedirs(output_dir, exist_ok=True)
-fig.savefig(os.path.join(output_dir, "nff_polarisation.png"), dpi=150)
+output_dir = pathlib.Path(__file__).parent / "output"
+output_dir.mkdir(exist_ok=True)
+fig.savefig(output_dir / "nff_polarisation.png", dpi=150)

--- a/examples/nff_polarisation.py
+++ b/examples/nff_polarisation.py
@@ -1,0 +1,41 @@
+import matplotlib
+matplotlib.use("Agg")
+
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+
+from qdot.nff import dephasing_polarisation_curve, non_dephased_polarisation
+
+Q0 = 0.8
+
+phases_left = [np.pi / 4, np.pi / 2, 3 * np.pi / 4]
+phase_labels = [r"$\pi/4$", r"$\pi/2$", r"$3\pi/4$"]
+
+phases_right = np.linspace(0, 2 * np.pi, 100)
+
+fig, (ax_left, ax_right) = plt.subplots(1, 2, figsize=(10, 4))
+
+for phase, label in zip(phases_left, phase_labels):
+    gamma_values, pol_values = dephasing_polarisation_curve(Q0, phase)
+    ax_left.plot(gamma_values, np.real(pol_values), label=f"phase = {label}")
+
+ax_left.set_xlabel(r"Dephasing parameter $\gamma$")
+ax_left.set_ylabel("z-polarisation")
+ax_left.set_title("Dephasing polarisation curves")
+ax_left.legend()
+
+pol_right = np.real([non_dephased_polarisation(Q0, ph) for ph in phases_right])
+
+ax_right.plot(phases_right, pol_right)
+ax_right.set_xlabel("Pulse phase (rad)")
+ax_right.set_ylabel("z-polarisation")
+ax_right.set_title("No-dephasing limit")
+ax_right.set_xticks([0, np.pi / 2, np.pi, 3 * np.pi / 2, 2 * np.pi])
+ax_right.set_xticklabels(["0", r"$\pi/2$", r"$\pi$", r"$3\pi/2$", r"$2\pi$"])
+
+plt.tight_layout()
+
+output_dir = os.path.join(os.path.dirname(__file__), "..", "claude-test-graphs")
+os.makedirs(output_dir, exist_ok=True)
+fig.savefig(os.path.join(output_dir, "nff_polarisation.png"), dpi=150)


### PR DESCRIPTION
## Summary

- Demonstrates `dephasing_polarisation_curve` and `non_dephased_polarisation` from `qdot.nff`
- Left panel: z-polarisation vs dephasing strength γ for three pulse phases (q0 = 0.8)
- Right panel: z-polarisation in the zero-dephasing limit as pulse phase sweeps 0 → 2π

**Fixes applied after physics review:**
- The underlying physics bug (invalid initial density matrix `[[1,1],[0,1]]` in `nff.py`) was fixed in PR #9 on main. This example calls the library functions and picks up the fix automatically via the editable install.
- Added module docstring explaining the two panels
- Fixed import ordering (stdlib before third-party)
- Replaced `os.path` with `pathlib`
- Output path uses `pathlib.Path(__file__).parent / "output"`

## Test plan
- [x] Script runs without errors
- [x] Polarisation values are real and within [-q0, q0] = [-0.8, 0.8] ✓
- [x] Left panel: all curves converge to 0 at γ = 0.5 (maximum dephasing) ✓
- [x] Right panel: periodic in pulse phase ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)