### PR TITLE
Add type hints to all qdot modules; bump minimum Python to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "qdot"
 version = "0.1.0"
 description = "Nuclear spin dynamics simulations for InGaAs quantum dots"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.25",
     "scipy>=1.11",  # original code pinned <1.11 due to a suspected scipy.optimize breakage

--- a/qdot/correlators.py
+++ b/qdot/correlators.py
@@ -11,6 +11,7 @@ uses multiprocessing.Pool.starmap and scales to available CPU cores.
 
 import logging
 import multiprocessing
+import pathlib
 import numpy as np
 import qutip
 import scipy.constants as const
@@ -24,7 +25,9 @@ _VALID_SPECIES = frozenset(species_dict)
 logger = logging.getLogger(__name__)
 
 
-def spin_correlator(t, nuclear_hamiltonian, spin_axis):
+def spin_correlator(
+    t: float, nuclear_hamiltonian: qutip.Qobj, spin_axis: str
+) -> float | None:
     """
     Time correlation function <I_α(t) I_α(0)> for a single nuclear spin.
 
@@ -54,16 +57,16 @@ def spin_correlator(t, nuclear_hamiltonian, spin_axis):
 
 
 def site_correlator(
-    t,
-    zeeman_per_tesla,
-    quadrupole_coupling,
-    spin,
-    biaxiality,
-    euler_angles,
-    V_ZZ,
-    applied_field,
-    spin_axis,
-):
+    t: float,
+    zeeman_per_tesla: float,
+    quadrupole_coupling: float,
+    spin: float,
+    biaxiality: float,
+    euler_angles: np.ndarray,
+    V_ZZ: float,
+    applied_field: float,
+    spin_axis: str,
+) -> float:
     """
     Spin correlator at a single lattice site.
 
@@ -95,18 +98,18 @@ def site_correlator(
 
 
 def _parallel_site_correlator(
-    t,
-    zeeman_per_tesla,
-    quadrupole_coupling,
-    spin,
-    biaxiality,
-    alpha,
-    beta,
-    gamma,
-    V_ZZ,
-    applied_field,
-    spin_axis,
-):
+    t: float,
+    zeeman_per_tesla: float,
+    quadrupole_coupling: float,
+    spin: float,
+    biaxiality: float,
+    alpha: float,
+    beta: float,
+    gamma: float,
+    V_ZZ: float,
+    applied_field: float,
+    spin_axis: str,
+) -> float:
     """Single-site correlator with unpacked Euler angles, suitable for Pool.starmap."""
     H = faraday_hamiltonian(
         zeeman_per_tesla * applied_field,
@@ -121,8 +124,14 @@ def _parallel_site_correlator(
 
 
 def _build_starmap_args(
-    t, applied_field, spin_axis, nuclear_species, region_bounds, data_dir, step_size
-):
+    t: float,
+    applied_field: float,
+    spin_axis: str,
+    nuclear_species: str,
+    region_bounds: list[int],
+    data_dir: pathlib.Path | str,
+    step_size: int,
+) -> tuple[int, list[tuple]]:
     """Package per-site parameters into a list suitable for Pool.starmap."""
     eta, _, _, V_ZZ_arr, euler_angles = load_efg(
         data_dir, nuclear_species, region_bounds, step_size
@@ -161,14 +170,14 @@ def _build_starmap_args(
 
 
 def run_correlator_series(
-    data_dir,
-    timerange,
-    applied_field,
-    nuclear_species,
-    region_bounds,
-    step_size=100,
-    chunksize=25,
-):
+    data_dir: pathlib.Path | str,
+    timerange: np.ndarray,
+    applied_field: float,
+    nuclear_species: str,
+    region_bounds: list[int],
+    step_size: int = 100,
+    chunksize: int = 25,
+) -> np.ndarray:
     """
     Compute the spin correlator time series for one species in parallel.
 
@@ -188,7 +197,9 @@ def run_correlator_series(
         ndarray: Shape (3, len(timerange)), axes ordered x, y, z.
     """
     if nuclear_species not in _VALID_SPECIES:
-        raise ValueError(f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}")
+        raise ValueError(
+            f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}"
+        )
     results = np.zeros((3, len(timerange)))
 
     with multiprocessing.Pool() as pool:
@@ -212,16 +223,16 @@ def run_correlator_series(
 
 
 def run_log_correlator_simulation(
-    data_dir,
-    save_dir,
-    min_time_exp,
-    max_time_exp,
-    n_times,
-    applied_field,
-    region_bounds=None,
-    step_size=100,
-    chunksize=25,
-):
+    data_dir: pathlib.Path | str,
+    save_dir: pathlib.Path | str,
+    min_time_exp: int,
+    max_time_exp: int,
+    n_times: int,
+    applied_field: float,
+    region_bounds: list[int] | None = None,
+    step_size: int = 100,
+    chunksize: int = 25,
+) -> None:
     """
     Compute and save log-spaced correlator data for all four nuclear species.
 
@@ -236,8 +247,6 @@ def run_log_correlator_simulation(
         step_size (int): Subsampling interval. Default 100.
         chunksize (int): Pool chunksize. Default 25.
     """
-    import pathlib
-
     save_dir = pathlib.Path(save_dir)
 
     if region_bounds is None:
@@ -273,16 +282,16 @@ def run_log_correlator_simulation(
 
 
 def run_linear_correlator_simulation(
-    data_dir,
-    save_dir,
-    min_time,
-    max_time,
-    timestep,
-    applied_field,
-    region_bounds=None,
-    step_size=100,
-    chunksize=25,
-):
+    data_dir: pathlib.Path | str,
+    save_dir: pathlib.Path | str,
+    min_time: float,
+    max_time: float,
+    timestep: float,
+    applied_field: float,
+    region_bounds: list[int] | None = None,
+    step_size: int = 100,
+    chunksize: int = 25,
+) -> None:
     """
     Compute and save linearly-spaced correlator data for all four nuclear species.
 
@@ -297,8 +306,6 @@ def run_linear_correlator_simulation(
         step_size (int): Subsampling interval. Default 100.
         chunksize (int): Pool chunksize. Default 25.
     """
-    import pathlib
-
     save_dir = pathlib.Path(save_dir)
 
     if region_bounds is None:

--- a/qdot/efg.py
+++ b/qdot/efg.py
@@ -11,7 +11,7 @@ from qdot.isotopes import species_dict, old_species_dict
 _VALID_SPECIES = frozenset(species_dict)
 
 
-def euler_angles_from_rot_mat(rot_mat):
+def euler_angles_from_rot_mat(rot_mat: np.ndarray) -> tuple[float, float, float]:
     """
     Extract Euler angles from a rotation matrix.
 
@@ -43,7 +43,13 @@ def euler_angles_from_rot_mat(rot_mat):
     return alpha, beta, gamma
 
 
-def calculate_efg(nuclear_species, xx_array, xz_array, zz_array, use_sundfors=False):
+def calculate_efg(
+    nuclear_species: str,
+    xx_array: np.ndarray,
+    xz_array: np.ndarray,
+    zz_array: np.ndarray,
+    use_sundfors: bool = False,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Calculate the EFG tensor at every lattice site from the local strain tensor.
 
@@ -63,7 +69,9 @@ def calculate_efg(nuclear_species, xx_array, xz_array, zz_array, use_sundfors=Fa
         euler_angles (ndarray): Euler angles to the PAF at each site, shape (n, m, 3).
     """
     if nuclear_species not in _VALID_SPECIES:
-        raise ValueError(f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}")
+        raise ValueError(
+            f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}"
+        )
     params = old_species_dict if use_sundfors else species_dict
     species = params[nuclear_species]
 
@@ -154,7 +162,9 @@ def calculate_efg_vectorised(
         euler_angles (ndarray): shape (n, m, 3).
     """
     if nuclear_species not in _VALID_SPECIES:
-        raise ValueError(f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}")
+        raise ValueError(
+            f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}"
+        )
     params = old_species_dict if use_sundfors else species_dict
     species = params[nuclear_species]
 

--- a/qdot/hamiltonians.py
+++ b/qdot/hamiltonians.py
@@ -9,7 +9,9 @@ import numpy as np
 import qutip
 
 
-def spin_rotator(alpha, beta, gamma, initial_spin):
+def spin_rotator(
+    alpha: float, beta: float, gamma: float, initial_spin: qutip.Qobj
+) -> qutip.Qobj:
     """
     Rotate a quantum spin operator using Euler angles (X-Y-Z convention).
 
@@ -32,8 +34,14 @@ def spin_rotator(alpha, beta, gamma, initial_spin):
 
 
 def faraday_hamiltonian(
-    zeeman_term, quadrupolar_term, biaxiality, particle_spin, alpha, beta, gamma
-):
+    zeeman_term: float,
+    quadrupolar_term: float,
+    biaxiality: float,
+    particle_spin: float,
+    alpha: float,
+    beta: float,
+    gamma: float,
+) -> qutip.Qobj:
     """
     Nuclear spin Hamiltonian in Faraday geometry (static B along z).
 
@@ -66,8 +74,14 @@ def faraday_hamiltonian(
 
 
 def voigt_hamiltonian(
-    zeeman_term, quadrupolar_term, biaxiality, particle_spin, alpha, beta, gamma
-):
+    zeeman_term: float,
+    quadrupolar_term: float,
+    biaxiality: float,
+    particle_spin: float,
+    alpha: float,
+    beta: float,
+    gamma: float,
+) -> qutip.Qobj:
     """
     Nuclear spin Hamiltonian in Voigt geometry (static B along x).
 
@@ -97,7 +111,13 @@ def voigt_hamiltonian(
     )
 
 
-def rf_hamiltonian(particle_spin, B_x, B_y, B_z, gamma_n=1):
+def rf_hamiltonian(
+    particle_spin: float,
+    B_x: float,
+    B_y: float,
+    B_z: float,
+    gamma_n: float = 1,
+) -> qutip.Qobj:
     """
     RF perturbation Hamiltonian for NMR transition rate calculations.
 
@@ -121,8 +141,14 @@ def rf_hamiltonian(particle_spin, B_x, B_y, B_z, gamma_n=1):
 
 
 def transition_rate(
-    mixing_hamiltonian, init_state, final_state, E_init, E_final, omega_rf, delta=10e3
-):
+    mixing_hamiltonian: qutip.Qobj,
+    init_state: qutip.Qobj,
+    final_state: qutip.Qobj,
+    E_init: float,
+    E_final: float,
+    omega_rf: float,
+    delta: float = 10e3,
+) -> float:
     """
     Transition rate between two eigenstates under an RF perturbation.
 

--- a/qdot/io.py
+++ b/qdot/io.py
@@ -26,7 +26,11 @@ logger = logging.getLogger(__name__)
 SOKOLOV_DOT_REGION = [100, 1200, 439, 880]
 
 
-def load_sokolov_data(data_dir, region_bounds, step_size=1):
+def load_sokolov_data(
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int],
+    step_size: int = 1,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Load strain tensor components from the Sokolov dataset.
 
@@ -53,7 +57,12 @@ def load_sokolov_data(data_dir, region_bounds, step_size=1):
     return xx, xz, zz
 
 
-def load_mirrored_data(data_dir, region_bounds, step_size=1, mirror_type="left_right"):
+def load_mirrored_data(
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int],
+    step_size: int = 1,
+    mirror_type: str = "left_right",
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Load a mirrored (synthetic) strain dataset.
 
@@ -74,7 +83,12 @@ def load_mirrored_data(data_dir, region_bounds, step_size=1, mirror_type="left_r
     return archive["full_xx_data"], archive["full_xy_data"], archive["full_yy_data"]
 
 
-def load_concentration_data(data_dir, region_bounds, step_size=1, method="cubic"):
+def load_concentration_data(
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int],
+    step_size: int = 1,
+    method: str = "cubic",
+) -> np.ndarray:
     """
     Load interpolated In115 concentration data from the Sokolov dataset.
 
@@ -97,14 +111,14 @@ def load_concentration_data(data_dir, region_bounds, step_size=1, method="cubic"
 
 
 def _efg_archive_path(
-    data_dir,
-    nuclear_species,
-    region_bounds,
-    step_size,
-    use_sundfors=False,
-    real_strain=True,
-    mirror_type="left_right",
-):
+    data_dir: pathlib.Path | str,
+    nuclear_species: str,
+    region_bounds: list[int],
+    step_size: int,
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+) -> pathlib.Path:
     """Build the canonical archive filename for a pre-computed EFG dataset."""
     data_dir = pathlib.Path(data_dir)
     base = f"{nuclear_species}_calculation_results_for_region{region_bounds}_with_step_size_{step_size}"
@@ -116,19 +130,19 @@ def _efg_archive_path(
 
 
 def save_efg(
-    data_dir,
-    nuclear_species,
-    region_bounds,
-    step_size,
-    eta,
-    V_XX,
-    V_YY,
-    V_ZZ,
-    euler_angles,
-    use_sundfors=False,
-    real_strain=True,
-    mirror_type="left_right",
-):
+    data_dir: pathlib.Path | str,
+    nuclear_species: str,
+    region_bounds: list[int],
+    step_size: int,
+    eta: np.ndarray,
+    V_XX: np.ndarray,
+    V_YY: np.ndarray,
+    V_ZZ: np.ndarray,
+    euler_angles: np.ndarray,
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+) -> None:
     """
     Save pre-computed EFG arrays to a .npz archive.
 
@@ -161,14 +175,14 @@ def save_efg(
 
 
 def load_efg(
-    data_dir,
-    nuclear_species,
-    region_bounds,
-    step_size=1,
-    use_sundfors=False,
-    real_strain=True,
-    mirror_type="left_right",
-):
+    data_dir: pathlib.Path | str,
+    nuclear_species: str,
+    region_bounds: list[int],
+    step_size: int = 1,
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """
     Load pre-computed EFG arrays from a .npz archive.
 

--- a/qdot/isotopes.py
+++ b/qdot/isotopes.py
@@ -16,6 +16,20 @@ Two parameter sets are provided:
     old_species_dict — Sundfors (1974) values, for comparison with older literature
 """
 
+from typing import TypedDict
+
+
+class SpeciesParameters(TypedDict):
+    short_name: str
+    name: str
+    graph_name: str
+    particle_spin: float
+    zeeman_frequency_per_tesla: float
+    quadrupole_moment: float
+    S11: float
+    S44: float
+
+
 In_115 = {
     "short_name": "In_115",
     "name": "Indium 115",
@@ -104,9 +118,14 @@ As_75_Old = {
     "S44": 7.94e22,
 }
 
-species_dict = {"Ga69": Ga_69, "Ga71": Ga_71, "As75": As_75, "In115": In_115}
+species_dict: dict[str, SpeciesParameters] = {
+    "Ga69": Ga_69,
+    "Ga71": Ga_71,
+    "As75": As_75,
+    "In115": In_115,
+}
 
-old_species_dict = {
+old_species_dict: dict[str, SpeciesParameters] = {
     "Ga69": Ga_69_Old,
     "Ga71": Ga_71_Old,
     "As75": As_75_Old,

--- a/qdot/machine_gun.py
+++ b/qdot/machine_gun.py
@@ -14,7 +14,7 @@ from scipy.linalg import expm
 import qutip
 
 
-def state_constructor(n_photons):
+def state_constructor(n_photons: int) -> np.ndarray:
     """
     Build the initial |0...0⟩ state vector for the dot + n_photons system.
 
@@ -31,12 +31,14 @@ def state_constructor(n_photons):
     return state
 
 
-def state_to_density_matrix(state):
+def state_to_density_matrix(state: np.ndarray) -> np.ndarray:
     """Convert a state vector to a density matrix via outer product."""
     return np.outer(state, state)
 
 
-def single_qubit_operation(operator, n_qubits, target_qubit):
+def single_qubit_operation(
+    operator: np.ndarray, n_qubits: int, target_qubit: int
+) -> np.ndarray:
     """
     Embed a single-qubit operator into the full n_qubit Hilbert space.
 
@@ -70,7 +72,9 @@ def single_qubit_operation(operator, n_qubits, target_qubit):
     return result
 
 
-def controlled_unitary(n_photons, target_photon, unitary=None):
+def controlled_unitary(
+    n_photons: int, target_photon: int, unitary: np.ndarray | None = None
+) -> np.ndarray:
     """
     Construct a controlled-unitary gate with the dot as control.
 
@@ -98,7 +102,7 @@ def controlled_unitary(n_photons, target_photon, unitary=None):
     return first_term + second_term
 
 
-def cnot_array(n_photons):
+def cnot_array(n_photons: int) -> np.ndarray:
     """
     Build an array of CNOT operators, one per photon.
 
@@ -108,13 +112,12 @@ def cnot_array(n_photons):
     Returns:
         ndarray of Qobj: CNOT operators, shape (n_photons,).
     """
-    return np.array([
-        qutip.Qobj(controlled_unitary(n_photons, i + 1))
-        for i in range(n_photons)
-    ])
+    return np.array(
+        [qutip.Qobj(controlled_unitary(n_photons, i + 1)) for i in range(n_photons)]
+    )
 
 
-def perfect_cluster_state_machine_gun(n_photons):
+def perfect_cluster_state_machine_gun(n_photons: int) -> np.ndarray:
     """
     Operator for the ideal cluster-state machine gun on n_photons qubits.
 
@@ -139,7 +142,7 @@ def perfect_cluster_state_machine_gun(n_photons):
     return total
 
 
-def operational_perfect_machine_gun(n_photons):
+def operational_perfect_machine_gun(n_photons: int) -> np.ndarray:
     """
     Apply the perfect machine gun to the |0...0⟩ initial state.
 
@@ -154,7 +157,9 @@ def operational_perfect_machine_gun(n_photons):
     return operator @ initial
 
 
-def machine_gun_with_pauli_errors(n_photons, errors_array):
+def machine_gun_with_pauli_errors(
+    n_photons: int, errors_array: np.ndarray
+) -> np.ndarray:
     """
     Machine gun operator with Pauli errors applied to the dot during each cycle.
 
@@ -178,7 +183,9 @@ def machine_gun_with_pauli_errors(n_photons, errors_array):
     for i in range(n_photons):
         cnot = controlled_unitary(n_photons, i + 1)
         if errors_array[i, 0] == 1:
-            error_mat = single_qubit_operation(error_ops[errors_array[i, 1]], n_photons + 1, 1)
+            error_mat = single_qubit_operation(
+                error_ops[errors_array[i, 1]], n_photons + 1, 1
+            )
         else:
             error_mat = np.eye(2 ** (n_photons + 1))
         total = dot_rotator @ cnot @ error_mat @ total

--- a/qdot/nff.py
+++ b/qdot/nff.py
@@ -9,7 +9,7 @@ import numpy as np
 import qutip
 
 
-def dephasing_kraus_operator(dephasing_value):
+def dephasing_kraus_operator(dephasing_value: float) -> qutip.Qobj:
     """
     Superoperator for phase damping with a given dephasing strength.
 
@@ -25,7 +25,7 @@ def dephasing_kraus_operator(dephasing_value):
     return qutip.superop_reps.kraus_to_super([K_0, K_1])
 
 
-def pulse_kraus_operator(q0, phase):
+def pulse_kraus_operator(q0: float, phase: float) -> qutip.Qobj:
     """
     Superoperator for an optical pulse with coherence q0 and phase shift.
 
@@ -42,13 +42,15 @@ def pulse_kraus_operator(q0, phase):
     return qutip.superop_reps.kraus_to_super([E_0, E_1, E_2])
 
 
-def z_polarisation(density_matrix):
+def z_polarisation(density_matrix: qutip.Qobj) -> complex:
     """Z-axis polarisation of a density matrix (in X basis)."""
     Z_in_X = qutip.Qobj(np.array([[0, 1], [1, 0]]))
     return (Z_in_X * density_matrix).tr()
 
 
-def dephasing_polarisation_curve(q0, phase, n_gammas=100):
+def dephasing_polarisation_curve(
+    q0: float, phase: float, n_gammas: int = 100
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Z polarisation as a function of dephasing strength after one pulse.
 
@@ -78,7 +80,7 @@ def dephasing_polarisation_curve(q0, phase, n_gammas=100):
     return dephasing_list, np.real_if_close(z_pol_list)
 
 
-def non_dephased_polarisation(q0, phase):
+def non_dephased_polarisation(q0: float, phase: float) -> float:
     """
     Z polarisation after a single perfect (undephased) pulse.
 

--- a/qdot/nmr.py
+++ b/qdot/nmr.py
@@ -6,6 +6,8 @@ under an RF perturbation, building up an absorption spectrum by summing
 over all allowed transitions at each RF frequency.
 """
 
+import pathlib
+
 import numpy as np
 import scipy.constants as const
 from itertools import permutations
@@ -26,16 +28,16 @@ e = const.e
 
 
 def absorption_spectrum(
-    nuclear_species,
-    applied_field,
-    field_geometry,
-    rf_freq_list,
-    location,
-    data_dir,
-    region_bounds=None,
-    rf_field=5e-3,
-    use_sundfors=False,
-):
+    nuclear_species: str,
+    applied_field: float,
+    field_geometry: str,
+    rf_freq_list: np.ndarray,
+    location: tuple[int, int],
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int] | None = None,
+    rf_field: float = 5e-3,
+    use_sundfors: bool = False,
+) -> np.ndarray:
     """
     NMR absorption spectrum at a single lattice site.
 
@@ -57,7 +59,9 @@ def absorption_spectrum(
         ndarray: Transition rate at each RF frequency, shape (len(rf_freq_list),).
     """
     if nuclear_species not in _VALID_SPECIES:
-        raise ValueError(f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}")
+        raise ValueError(
+            f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}"
+        )
     if region_bounds is None:
         region_bounds = SOKOLOV_DOT_REGION
 
@@ -121,14 +125,14 @@ def absorption_spectrum(
 
 
 def varied_field_spectra(
-    nuclear_species,
-    applied_field_list,
-    field_geometry,
-    rf_freq_list,
-    location,
-    data_dir,
-    region_bounds=None,
-):
+    nuclear_species: str,
+    applied_field_list: list[float],
+    field_geometry: str,
+    rf_freq_list: np.ndarray,
+    location: tuple[int, int],
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int] | None = None,
+) -> list[dict]:
     """
     Compute absorption spectra at multiple applied field strengths.
 

--- a/qdot/plot.py
+++ b/qdot/plot.py
@@ -6,6 +6,7 @@ Pass save_path (str or Path) to save instead of displaying.
 """
 
 import pathlib
+
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
@@ -20,7 +21,11 @@ from qdot.isotopes import species_dict
 # ---------------------------------------------------------------------------
 
 
-def plot_equivalent_b_field(nuclear_species, b_field_array, save_path=None):
+def plot_equivalent_b_field(
+    nuclear_species: str,
+    b_field_array: np.ndarray,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     Heatmap of the equivalent magnetic field for one nuclear species.
 
@@ -42,7 +47,11 @@ def plot_equivalent_b_field(nuclear_species, b_field_array, save_path=None):
     return fig
 
 
-def plot_all_equivalent_b_fields(b_field_arrays, region_bounds=None, save_path=None):
+def plot_all_equivalent_b_fields(
+    b_field_arrays: list[np.ndarray],
+    region_bounds: list[int] | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     2×2 grid of equivalent B-field heatmaps, one per nuclear species.
 
@@ -80,12 +89,12 @@ def plot_all_equivalent_b_fields(b_field_arrays, region_bounds=None, save_path=N
 
 
 def plot_strain_lattice(
-    simulated_species,
-    unstrained_positions,
-    strained_positions,
-    real_atoms=True,
-    save_path=None,
-):
+    simulated_species: np.ndarray,
+    unstrained_positions: np.ndarray,
+    strained_positions: np.ndarray,
+    real_atoms: bool = True,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     Overlay plot of unstrained and strained lattice positions and bonds.
 
@@ -167,7 +176,11 @@ def plot_strain_lattice(
     return fig
 
 
-def plot_strain_tensors(strain_tensor_array, absolute_values=False, save_path=None):
+def plot_strain_tensors(
+    strain_tensor_array: np.ndarray,
+    absolute_values: bool = False,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     Three-panel plot of ε_xx, ε_xy, and ε_yy strain components.
 
@@ -210,7 +223,10 @@ def plot_strain_tensors(strain_tensor_array, absolute_values=False, save_path=No
 # ---------------------------------------------------------------------------
 
 
-def plot_concentration(conc_data, save_path=None):
+def plot_concentration(
+    conc_data: np.ndarray,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     Heatmap of In115 concentration across the dot.
 
@@ -232,7 +248,11 @@ def plot_concentration(conc_data, save_path=None):
     return fig
 
 
-def plot_concentration_with_regions(conc_data, rect_specs, save_path=None):
+def plot_concentration_with_regions(
+    conc_data: np.ndarray,
+    rect_specs: list[tuple[float, float, float, float]],
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     Concentration heatmap with highlighted rectangular regions overlaid.
 
@@ -266,13 +286,13 @@ def plot_concentration_with_regions(conc_data, rect_specs, save_path=None):
 
 
 def plot_correlator(
-    timerange,
-    correlator_data,
-    nuclear_species,
-    applied_field,
-    log_time=False,
-    save_path=None,
-):
+    timerange: np.ndarray,
+    correlator_data: np.ndarray,
+    nuclear_species: str,
+    applied_field: float,
+    log_time: bool = False,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     Plot spin correlator time series for all three axes.
 
@@ -303,8 +323,13 @@ def plot_correlator(
 
 
 def plot_fourier_transform(
-    timerange, correlator_data, timestep, nuclear_species, applied_field, save_path=None
-):
+    timerange: np.ndarray,
+    correlator_data: np.ndarray,
+    timestep: float,
+    nuclear_species: str,
+    applied_field: float,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
     """
     Plot the Fourier transform of a linearly-spaced correlator time series.
 
@@ -340,7 +365,7 @@ def plot_fourier_transform(
 # ---------------------------------------------------------------------------
 
 
-def _save_or_show(fig, save_path):
+def _save_or_show(fig: plt.Figure, save_path: pathlib.Path | str | None) -> None:
     if save_path is not None:
         fig.savefig(pathlib.Path(save_path))
     else:

--- a/qdot/strain.py
+++ b/qdot/strain.py
@@ -18,7 +18,9 @@ from scipy.spatial import distance_matrix as scipy_distance_matrix
 # ---------------------------------------------------------------------------
 
 
-def _bond_parameters(real_atoms=True):
+def _bond_parameters(
+    real_atoms: bool = True,
+) -> tuple[dict[str, float], dict[str, float]]:
     """Return (spring_constants, natural_lengths) dicts keyed by species-pair string."""
     if real_atoms:
         # Stiffnesses from Vurgaftman 2001, DOI: 10.1063/1.1368156
@@ -75,7 +77,7 @@ def _bond_parameters(real_atoms=True):
 # ---------------------------------------------------------------------------
 
 
-def _gaas_base_lattice(n_rows, n_cols):
+def _gaas_base_lattice(n_rows: int, n_cols: int) -> np.ndarray:
     """GaAs alternating lattice with a 2-cell border for boundary conditions."""
     large = np.zeros((n_rows + 2, n_cols + 2), dtype=int)
     for r in range(n_rows + 2):
@@ -86,13 +88,15 @@ def _gaas_base_lattice(n_rows, n_cols):
     return large
 
 
-def gaas_lattice(n_rows, n_cols):
+def gaas_lattice(n_rows: int, n_cols: int) -> tuple[np.ndarray, np.ndarray]:
     """Pure GaAs lattice, no Indium."""
     large = _gaas_base_lattice(n_rows, n_cols)
     return large, large[1 : n_rows + 1, 1 : n_cols + 1]
 
 
-def gaas_lattice_with_indium_centre(n_rows, n_cols):
+def gaas_lattice_with_indium_centre(
+    n_rows: int, n_cols: int
+) -> tuple[np.ndarray, np.ndarray]:
     """GaAs lattice with a single In atom at the centre."""
     large = _gaas_base_lattice(n_rows, n_cols)
     cr, cc = int(math.floor(n_rows / 2)) + 1, int(math.floor(n_cols / 2)) + 1
@@ -101,7 +105,9 @@ def gaas_lattice_with_indium_centre(n_rows, n_cols):
     return large, large[1 : n_rows + 1, 1 : n_cols + 1]
 
 
-def gaas_lattice_with_indium(n_rows, n_cols, in_positions):
+def gaas_lattice_with_indium(
+    n_rows: int, n_cols: int, in_positions: list[list[int]]
+) -> tuple[np.ndarray, np.ndarray]:
     """
     GaAs lattice with In atoms placed at specified positions.
 
@@ -121,7 +127,7 @@ def gaas_lattice_with_indium(n_rows, n_cols, in_positions):
     return large, large[1 : n_rows + 1, 1 : n_cols + 1]
 
 
-def block_in_positions(bottom_left, top_right):
+def block_in_positions(bottom_left: list[int], top_right: list[int]) -> list[list[int]]:
     """Generate a rectangular block of In positions."""
     return [
         [i, j]
@@ -135,11 +141,13 @@ def block_in_positions(bottom_left, top_right):
 # ---------------------------------------------------------------------------
 
 
-def _n_springs(n_rows, n_cols):
+def _n_springs(n_rows: int, n_cols: int) -> int:
     return 2 * n_rows * n_cols + n_rows + n_cols
 
 
-def spring_constants_from_lattice(large_species_array, real_atoms=True):
+def spring_constants_from_lattice(
+    large_species_array: np.ndarray, real_atoms: bool = True
+) -> np.ndarray:
     """Extract spring constant for each spring from the species array."""
     k_dict, _ = _bond_parameters(real_atoms)
     n_rows = large_species_array.shape[0] - 2
@@ -167,7 +175,9 @@ def spring_constants_from_lattice(large_species_array, real_atoms=True):
     return constants
 
 
-def natural_lengths_from_lattice(large_species_array, real_atoms=True):
+def natural_lengths_from_lattice(
+    large_species_array: np.ndarray, real_atoms: bool = True
+) -> np.ndarray:
     """Extract natural (rest) length for each spring from the species array."""
     _, n_dict = _bond_parameters(real_atoms)
     n_rows = large_species_array.shape[0] - 2
@@ -196,7 +206,13 @@ def natural_lengths_from_lattice(large_species_array, real_atoms=True):
 # ---------------------------------------------------------------------------
 
 
-def _positions_to_spring_lengths(coords, box_width, box_height, n_rows, n_cols):
+def _positions_to_spring_lengths(
+    coords: np.ndarray,
+    box_width: float,
+    box_height: float,
+    n_rows: int,
+    n_cols: int,
+) -> np.ndarray:
     coords = np.reshape(coords, (n_rows, n_cols, 2))
     n_s = _n_springs(n_rows, n_cols)
     lengths = np.full(n_s, 1000.0)
@@ -232,15 +248,21 @@ def _positions_to_spring_lengths(coords, box_width, box_height, n_rows, n_cols):
 
 
 def _potential_energy(
-    coords, spring_k, natural_l, box_width, box_height, n_rows, n_cols
-):
+    coords: np.ndarray,
+    spring_k: np.ndarray,
+    natural_l: np.ndarray,
+    box_width: float,
+    box_height: float,
+    n_rows: int,
+    n_cols: int,
+) -> float:
     lengths = _positions_to_spring_lengths(
         coords, box_width, box_height, n_rows, n_cols
     )
     return np.sum(spring_k * (lengths - natural_l) ** 2)
 
 
-def unstrained_positions(n_rows, n_cols):
+def unstrained_positions(n_rows: int, n_cols: int) -> np.ndarray:
     """Equilibrium (unstrained) atomic positions on a regular grid."""
     box_h = n_rows + 2
     box_w = n_cols + 2
@@ -259,7 +281,9 @@ def unstrained_positions(n_rows, n_cols):
 # ---------------------------------------------------------------------------
 
 
-def strain_tensor(strained_coords, unstrained_coords):
+def strain_tensor(
+    strained_coords: np.ndarray, unstrained_coords: np.ndarray
+) -> np.ndarray:
     """
     Calculate the 2D strain tensor at each atomic site.
 
@@ -303,8 +327,13 @@ def strain_tensor(strained_coords, unstrained_coords):
 
 
 def run_strain_simulation(
-    n_rows, n_cols, lattice_type=0, in_positions=None, real_atoms=True, decimal_places=3
-):
+    n_rows: int,
+    n_cols: int,
+    lattice_type: int = 0,
+    in_positions: list[list[int]] | None = None,
+    real_atoms: bool = True,
+    decimal_places: int = 3,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float, float, float]:
     """
     Find the relaxed strained lattice by energy minimisation.
 


### PR DESCRIPTION
## Summary

- Adds `SpeciesParameters` TypedDict in `isotopes.py` so callers know the exact shape of each species dict; annotates `species_dict` and `old_species_dict`
- Annotates all public functions and key private helpers across `efg`, `hamiltonians`, `correlators`, `io`, `nmr`, `nff`, `plot`, `strain`, and `machine_gun`
- Uses native 3.10 `X | Y` union syntax throughout — no `from __future__` imports
- Bumps `requires-python` to `>=3.10` to match
- Moves two inline `import pathlib` statements inside `correlators.py` functions to the top-level

## Test plan

- [ ] `pytest tests/` — 53 passed, 0 failures
- [ ] `black .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)