### PR TITLE
Add software correctness tests for hamiltonians, correlators, and efg

### DIFF
--- a/tests/test_correlators.py
+++ b/tests/test_correlators.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 import qutip
 from qdot.hamiltonians import faraday_hamiltonian
-from qdot.correlators import spin_correlator, site_correlator
+from qdot.correlators import spin_correlator, site_correlator, run_correlator_series
+from qdot.io import save_efg
 
 
 def _simple_hamiltonian():
@@ -75,3 +76,45 @@ def test_site_correlator_matches_spin_correlator():
     )
     expected = spin_correlator(t, H, "z")
     assert abs(result - expected) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# run_correlator_series
+# ---------------------------------------------------------------------------
+
+_BOUNDS = [0, 2, 0, 2]
+_RNG = np.random.default_rng(7)
+
+
+@pytest.fixture
+def efg_dir(tmp_path):
+    """Write a tiny (2×2) synthetic EFG archive for Ga69 to tmp_path."""
+    shape = (2, 2)
+    eta = _RNG.uniform(0.0, 1.0, shape)
+    V_XX = _RNG.uniform(-1e14, 1e14, shape)
+    V_YY = _RNG.uniform(-1e14, 1e14, shape)
+    V_ZZ = _RNG.uniform(1e13, 1e14, shape)
+    euler_angles = _RNG.uniform(0, 2 * np.pi, (*shape, 3))
+    save_efg(tmp_path, "Ga69", _BOUNDS, 1, eta, V_XX, V_YY, V_ZZ, euler_angles)
+    return tmp_path
+
+
+def test_run_correlator_series_output_shape(efg_dir):
+    timerange = np.array([0.0, 1e-9])
+    result = run_correlator_series(
+        efg_dir, timerange, 1.0, "Ga69", _BOUNDS, step_size=1
+    )
+    assert result.shape == (3, 2)
+
+
+def test_run_correlator_series_values_are_finite(efg_dir):
+    timerange = np.array([0.0, 1e-9])
+    result = run_correlator_series(
+        efg_dir, timerange, 1.0, "Ga69", _BOUNDS, step_size=1
+    )
+    assert np.all(np.isfinite(result))
+
+
+def test_run_correlator_series_invalid_species_raises(efg_dir):
+    with pytest.raises(ValueError, match="nuclear_species"):
+        run_correlator_series(efg_dir, np.array([0.0]), 1.0, "Xx99", _BOUNDS)

--- a/tests/test_efg.py
+++ b/tests/test_efg.py
@@ -267,3 +267,65 @@ class TestVectorisedEFG:
                     atol=1e-10,
                     err_msg=f"Euler reconstruction failed at site ({i},{j})",
                 )
+
+
+# ---------------------------------------------------------------------------
+# Multi-species Euler angle coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("species", ["Ga71", "As75", "In115"])
+def test_euler_angles_reconstruct_rotation_all_species(species):
+    """
+    Euler angles extracted by calculate_efg_vectorised must reconstruct the
+    rotation matrix for all species, not just Ga69.
+
+    Uses the same round-trip check as test_euler_angles_reconstruct_rotation
+    but parameterised over the three remaining species.
+    """
+    from qdot.isotopes import species_dict as sd
+
+    def euler_to_rot(alpha, beta, gamma):
+        ca, sa = np.cos(alpha), np.sin(alpha)
+        cb, sb = np.cos(beta), np.sin(beta)
+        cg, sg = np.cos(gamma), np.sin(gamma)
+        Rx = np.array([[1, 0, 0], [0, ca, -sa], [0, sa, ca]])
+        Ry = np.array([[cb, 0, sb], [0, 1, 0], [-sb, 0, cb]])
+        Rz = np.array([[cg, -sg, 0], [sg, cg, 0], [0, 0, 1]])
+        return Rz @ Ry @ Rx
+
+    n, m = 4, 4
+    xx, xz, zz = _make_strain((n, m), seed=42)
+
+    S11 = sd[species]["S11"]
+    S12 = -S11 / 2
+    S44 = sd[species]["S44"]
+
+    V = np.zeros((n, m, 3, 3))
+    V[:, :, 0, 0] = S12 * (zz - xx)
+    V[:, :, 1, 1] = (S12 + S11) * xx + S12 * zz
+    V[:, :, 2, 2] = 2 * S12 * xx + S11 * zz
+    V[:, :, 0, 2] = V[:, :, 2, 0] = S44 * xz
+    V[:, :, 1, 2] = V[:, :, 2, 1] = S44 * xz
+
+    w, v = np.linalg.eigh(V)
+    sort_idx = np.argsort(np.abs(w), axis=-1)[:, :, ::-1]
+    sort_idx_v = np.broadcast_to(sort_idx[:, :, np.newaxis, :], (n, m, 3, 3))
+    v_sorted = np.take_along_axis(v, sort_idx_v, axis=-1)
+    rot = np.stack(
+        [v_sorted[:, :, :, 2], v_sorted[:, :, :, 1], v_sorted[:, :, :, 0]], axis=-1
+    )
+    rot[:, :, :, 2] = np.cross(rot[:, :, :, 0], rot[:, :, :, 1])
+
+    _, _, _, _, euler_v = calculate_efg_vectorised(species, xx, xz, zz)
+
+    for i in range(n):
+        for j in range(m):
+            a, b, g = euler_v[i, j]
+            R_rec = euler_to_rot(a, b, g)
+            np.testing.assert_allclose(
+                R_rec,
+                rot[i, j],
+                atol=1e-10,
+                err_msg=f"{species}: Euler reconstruction failed at ({i},{j})",
+            )

--- a/tests/test_hamiltonians.py
+++ b/tests/test_hamiltonians.py
@@ -1,7 +1,13 @@
 import numpy as np
 import pytest
 import qutip
-from qdot.hamiltonians import faraday_hamiltonian, voigt_hamiltonian, spin_rotator
+from qdot.hamiltonians import (
+    faraday_hamiltonian,
+    rf_hamiltonian,
+    transition_rate,
+    voigt_hamiltonian,
+    spin_rotator,
+)
 
 
 def test_faraday_hamiltonian_is_hermitian():
@@ -43,3 +49,80 @@ def test_spin_rotator_2pi_is_identity():
     # For integer representation, 2π gives +identity; for half-integer, -identity.
     # jmat(3/2) lives in a 4×4 space; the rotation acts on operators so sign cancels.
     assert (result - op).norm() < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# voigt_hamiltonian
+# ---------------------------------------------------------------------------
+
+
+def test_voigt_pure_zeeman_eigenvalues():
+    # Pure Zeeman in Voigt geometry uses I_x; eigenvalues are the same set as
+    # Faraday (±1/2, ±3/2 for spin-3/2) regardless of which axis carries the field.
+    H = voigt_hamiltonian(1.0, 0.0, 0.0, 1.5, 0.0, 0.0, 0.0)
+    eigs = np.sort(np.real(H.eigenenergies()))
+    expected = np.array([-1.5, -0.5, 0.5, 1.5])
+    np.testing.assert_allclose(eigs, expected, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# rf_hamiltonian
+# ---------------------------------------------------------------------------
+
+
+def test_rf_hamiltonian_is_hermitian():
+    H = rf_hamiltonian(1.5, B_x=1.0, B_y=0.5, B_z=0.0)
+    assert (H - H.dag()).norm() < 1e-10
+
+
+def test_rf_hamiltonian_correct_dims():
+    H = rf_hamiltonian(1.5, B_x=1.0, B_y=0.0, B_z=0.0)
+    assert H.dims == [[4], [4]]
+
+
+def test_rf_hamiltonian_zero_field_is_zero():
+    H = rf_hamiltonian(1.5, B_x=0.0, B_y=0.0, B_z=0.0)
+    assert H.norm() < 1e-10
+
+
+def test_rf_hamiltonian_scales_with_field():
+    H1 = rf_hamiltonian(1.5, B_x=1.0, B_y=0.0, B_z=0.0)
+    H2 = rf_hamiltonian(1.5, B_x=2.0, B_y=0.0, B_z=0.0)
+    assert (H2 - 2 * H1).norm() < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# transition_rate
+# ---------------------------------------------------------------------------
+
+
+def _eigenstates_spin32():
+    """Return eigenstates and energies for a simple spin-3/2 Hamiltonian."""
+    H = faraday_hamiltonian(1.0, 0.1, 0.4, 1.5, 0.0, 0.0, 0.0)
+    energies, states = H.eigenstates()
+    return energies, states
+
+
+def test_transition_rate_is_nonnegative():
+    energies, states = _eigenstates_spin32()
+    H_rf = rf_hamiltonian(1.5, B_x=1.0, B_y=0.0, B_z=0.0)
+    rate = transition_rate(H_rf, states[0], states[1], energies[0], energies[1], 0.0)
+    assert rate >= 0
+
+
+def test_transition_rate_returns_scalar():
+    energies, states = _eigenstates_spin32()
+    H_rf = rf_hamiltonian(1.5, B_x=1.0, B_y=0.0, B_z=0.0)
+    rate = transition_rate(H_rf, states[0], states[1], energies[0], energies[1], 0.0)
+    assert np.ndim(rate) == 0
+
+
+def test_transition_rate_on_resonance_exceeds_off_resonance():
+    energies, states = _eigenstates_spin32()
+    H_rf = rf_hamiltonian(1.5, B_x=1.0, B_y=0.0, B_z=0.0)
+    gap = energies[1] - energies[0]
+    rate_on = transition_rate(H_rf, states[0], states[1], energies[0], energies[1], gap)
+    rate_off = transition_rate(
+        H_rf, states[0], states[1], energies[0], energies[1], gap * 1000
+    )
+    assert rate_on > rate_off


### PR DESCRIPTION
## Summary

Fills the software correctness gaps identified in the test coverage review.

**`test_hamiltonians.py`** (+8 tests)
- `rf_hamiltonian`: Hermitian, correct dims, zero field → zero operator, linearity under field scaling
- `transition_rate`: non-negative, returns scalar, on-resonance > off-resonance
- `voigt_hamiltonian`: pure Zeeman eigenvalues match expected ±½, ±3/2

**`test_correlators.py`** (+3 tests)
- `run_correlator_series`: output shape `(3, n_times)`, all values finite, invalid species raises `ValueError`
- Uses a synthetic (2×2) EFG fixture via `save_efg` + `tmp_path`

**`test_efg.py`** (+3 parametrised tests)
- Euler angle round-trip reconstruction for Ga71, As75, and In115 (Ga69 was already covered)

## Test plan

- [ ] `pytest tests/` — 90 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)