### PR TITLE
Port the archive's experimental capabilities into qdot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ real-data-outputs/
 __pycache__/
 *.pyc
 *.egg-info/
+
+# Generated experiment outputs (graphs and cached maps)
+new_data_outputs/

--- a/archive-vs-module.md
+++ b/archive-vs-module.md
@@ -1,215 +1,440 @@
-# Archive vs. qdot Module — Functionality Gaps
+# Archive vs. qdot Module — Functionality Comparison and Porting Plan
 
-This document records what the original research scripts under `archive/` do that
-the `qdot` package does not yet cover, what `qdot` added that the archive lacks,
-and where something was ported but the interface changed significantly.
+This document compares the original research scripts under `archive/` with the
+`qdot` package, function by function, with particular attention to the
+experimental simulation scripts and graph generation. It then sets out a plan
+for porting the missing capabilities into `qdot`.
 
 The archive is historical reference only. `qdot/` supersedes it for all new work.
 
+Conventions used below: "full" means qdot reproduces the capability; "partial"
+means the computation or data exists but the driver/figure does not; "none"
+means nothing in qdot covers it.
+
 ---
 
-## What qdot adds (not in the archive)
+## 1. What qdot adds that the archive lacks
 
 | Addition | Location |
 |---|---|
 | Importable package with clean public API | `qdot/__init__.py`, `pyproject.toml` |
-| Explicit `data_dir` arguments — no hardcoded paths | all modules |
+| Explicit `data_dir` arguments — the archive hardcodes `/home/will/...` paths in every file | all modules |
 | Vectorised EFG calculation (`calculate_efg_vectorised`) | `qdot/efg.py` |
-| Vectorised strain energy and tensor (`_potential_energy_vectorised`, `strain_tensor_vectorised`) | `qdot/strain.py` |
-| Type hints throughout | all modules |
-| Test suite (137 tests across all modules) | `tests/` |
-| Physics bug fixes: `transition_rate` |M|→|M|², ρ normalisation, Kraus trace-preserving form, EFG improper-rotation fix, `pinv` in strain tensor | various |
-| Separation of computation from plotting (`qdot/plot.py`) | `qdot/plot.py` |
-| `logging` instead of `print()` | `qdot/io.py`, `qdot/correlators.py` |
-| `SOKOLOV_DOT_REGION` constant | `qdot/io.py` |
-| `load_mirrored_data` for reading symmetric datasets | `qdot/io.py` |
+| Vectorised strain energy and tensor calculations | `qdot/strain.py` |
+| Type hints throughout; tests (139); logging instead of `print()` | all modules, `tests/` |
+| Physics corrections: `transition_rate` \|M\|→\|M\|², ρ normalisation, trace-preserving Kraus operators (√γ·I vs the archive's γ·I), valid initial density matrix in NFF, FFT plotted as magnitude rather than real part, improper-rotation fix in EFG Euler angles, `pinv` in strain tensor | various |
+| Separation of computation from plotting | `qdot/plot.py` |
+| `save_efg` overwrite control and skip warnings; archive-name normalisation | `qdot/io.py` |
+
+Note on the NFF physics corrections: the archive's `DephasingKrausKreator` and
+its initial density matrix `[[1,1],[0,1]]` differ from `qdot/nff.py` by design —
+the qdot versions are the corrected forms. Any numerical comparison against
+archive NFF output will differ for this reason.
 
 ---
 
-## Gaps: archive functionality absent from qdot
+## 2. Fully ported (no action needed)
 
-### NMR spectra (`archive/NMR/spectra.py`)
+The shared engine (`archive/common_modules/backbone_quadrupolar_functions.py`,
+757 lines) is fully covered: data loaders (`load_strain_data`,
+`load_concentration_data`, `load_mirrored_data`), EFG calculation and archive
+save/load, Euler angle extraction, both Hamiltonian constructors,
+`rf_hamiltonian`, `transition_rate`, and the serial/parallel spin correlators.
+`isotope_parameters.py` (three duplicate copies in the archive) is consolidated
+into `qdot/isotopes.py`.
 
-The archive's NMR module is far larger than `qdot/nmr.py`. The main missing pieces:
-
-**Multi-site parallel computation**
-- `many_location_parallel_calculation` — runs `absorption_spectrum` across a list of
-  lattice sites using `multiprocessing.Pool`, summing contributions at each field value.
-  This is the NMR equivalent of `run_correlator_series`; it has no counterpart in `qdot`.
-- `load_many_location_data` / `many_location_parallel_plot` — load cached multi-site
-  absorption arrays and display as a 2D (field × frequency) heatmap.
-- `many_NMR_spectra_data_calculation` — batch driver that calls the above for all four
-  species and both geometries in one pass.
-
-**Full-experiment simulation**
-- `experimental_NMR_sim` — concentration-weighted multi-species, multi-site simulation.
-  Uses `load_In_concentration_data` to determine the In/Ga/As site counts, randomly
-  samples real lattice locations for each species, computes parallel absorption, sums
-  all species, and plots a log-scaled 2D absorption map that matches what an experimentalist
-  would record. No equivalent exists in `qdot`.
-- `experimental_NMR_sim_transparent_version` — same output with per-species transparent
-  overlaid panels for direct comparison.
-
-**Combined and analysed spectra**
-- `combined_species_single_spectra_data` / `combined_species_single_spectra_plot` —
-  computes the sum of all species' spectra at a single applied field, then detects and
-  marks peaks. Useful for identifying overlapping resonances.
-- `combined_species_single_spectra_plot_subregion` — as above but plots a frequency
-  sub-window with optional shaded highlight.
-- `pulse_graph_area_calculations` — integrates area under Lorentzian pulses as a
-  function of RF frequency width.
-
-**Site sampling utilities**
-- `random_locations_list_generator` — draws N random (x, y) lattice indices from a
-  named region. Used to create representative site samples without computing at every site.
-- `all_locations_list_generator` — enumerates all lattice positions in a region.
-
-**Parameter-set and geometry comparisons**
-- `Faraday_Voigt_spectra_comparison`, `side_by_side_comparison_plotter` — side-by-side
-  Faraday vs. Voigt geometry NMR plots at matching sites.
-- `Sundfors_Checkovich_comparison` / `GET_values_comparison_spectra` — runs spectra with
-  both Sundfors (1974) and Checkhovich GET values and plots them together for direct
-  parameter-set comparison.
+Also fully ported: the whole strain toy model (`neat_strain_toy_model.py` →
+`qdot/strain.py` + the two strain plots in `qdot/plot.py`), the state-vector
+machine gun (`machine_gun_basics.py`/`backbone_functions.py` →
+`qdot/machine_gun.py`), the correlator calculation drivers
+(`parallel_correlator.py` → `qdot/correlators.py`), the single-site NMR
+absorption spectrum, the correlator time-domain and FFT plots, the
+equivalent-B-field *plotters*, and the concentration map plots
+(`plot_concentration`, `plot_concentration_with_regions`).
 
 ---
 
-### Correlator Fourier analysis (`archive/correlator/parallel_correlator.py`)
+## 3. Gaps, by capability
 
-`qdot/correlators.py` covers the core time-domain computation and the save/load functions.
-What is missing is everything in the frequency domain:
+### 3.1 NMR: 2D field–frequency absorption maps (`archive/NMR/spectra.py`, 2774 lines)
 
-- `single_species_correlator_to_fourier` — loads a stored correlator archive, computes
-  the FFT along the time axis, and saves the result. Produces the spectral density
-  S(ω) from C(t).
-- `single_species_fourier_transform_grapher` — plots the FFT result, optionally alongside
-  the original time-domain curve.
-- `all_species_correlator_to_fourier` — batch version of the above across all four species
-  and a list of applied fields.
-- `all_species_logtime_correlator_grapher` — generates log-time correlator plots for all
-  species at multiple B-field values, intended for publication-style figure production.
+The single-site spectrum (`absorption_spectrum`) is the only part of the
+archive's NMR machinery that qdot has. Missing:
 
-There is also no load-and-plot function in `qdot` for the `.npz` archives that
-`run_log_correlator_simulation` writes.
+- **Multi-site parallel computation** — `many_location_parallel_calculation`
+  farms the per-site spectrum over a `multiprocessing.Pool` for each applied
+  field, sums over sites, and produces a (fields × frequencies) array. This is
+  the NMR analogue of `run_correlator_series`.
+- **Disk caching** — results saved as parameter-encoded `.npy` files,
+  recomputed only on `recalc=True` (`load_many_location_data`,
+  `many_NMR_spectra_data_calculation` batch driver over species × geometries).
+- **Map plotting** — log-scaled `imshow` heatmaps (x = RF frequency in MHz,
+  y = B in T), including named experiment presets (`large_hd_spectra`,
+  `region_characterisation_spectra`, `atomic_region_spectra`,
+  `gigahertz_range_spectra`) that fix the grids used for publication figures.
+- **Comparison figures** — Faraday−Voigt difference maps (diverging colormap),
+  side-by-side two-panel geometry comparison, side-by-side and difference maps
+  for Checkhovich vs Sundfors GET values with relabelled colorbars.
+- **Site sampling** — `random_locations_list_generator`,
+  `all_locations_list_generator`, and `find_best_locations`
+  (`random_point_searcher.py`), which snaps random seeds to local maxima of the
+  summed strain map so sampled sites sit on strongly-strained nuclei.
+
+### 3.2 NMR: concentration-weighted experimental simulation
+
+`experimental_NMR_sim` produces the figure closest to what an experimentalist
+measures: it loads the In concentration map, splits the sampled sites into
+In115/Ga69/As75 populations according to mean In concentration (As fixed at
+50%, the remainder split between Ga and In), computes each species' 2D map in
+parallel, and renders either the log-summed total or per-species transparent
+layers (`experimental_NMR_sim_transparent_version`, Greys/Blues/Reds with
+decreasing alpha). Nothing in qdot covers species mixing, and the species-split
+heuristic is a physics decision that needs confirming before porting.
+
+### 3.3 NMR: 1D line spectra and RF pulse selectivity analysis
+
+A second family of figures absent from qdot:
+
+- `single_field_line_spectra` — multi-site summed, normalised spectrum at one field.
+- `applied_field_comparison_line_spectra` — stacked subplots, one per field.
+- `RF_comparison_line_spectra`, `number_of_nuclei_comparison` — overlay curves
+  with an inset zoom on the 69–91 MHz window (ensemble-convergence studies).
+- Combined-species analysis: `combined_species_single_spectra_data` sums all
+  four isotopes over a shared site list at fixed B; the plot variants mark
+  `scipy.signal.find_peaks` peaks or shade a target frequency window.
+- Pulse selectivity: `create_lorentzian_pulse` models an RF pulse's frequency
+  profile; `overlaid_pulse_graphs` and `pulse_graph_area_calculations` /
+  `comparison_area_plots` multiply pulse × spectrum and Simpson-integrate to
+  report the fraction of total absorption captured in target vs off-target
+  windows as a function of pulse width. This was used to assess whether a
+  pulse can address one species without touching others.
+
+### 3.4 Energy-level diagrams (`archive/quadrupolar/splitting_graphs.py`)
+
+Entirely absent from qdot. The archive computes eigenenergies (MHz) of the
+site Hamiltonian swept over applied field (0–3 T) or biaxiality η (0–1), and
+plots:
+
+- single-site level diagrams (anti-crossings), per species and geometry;
+- two-panel Faraday | Voigt comparisons with shared y-limits;
+- ensemble versions overlaying all sites or n random sites in a region, which
+  visualise inhomogeneous level broadening across the dot;
+- mirrored-dot variants (`mirrored_data_plots.py`).
+
+`qdot/hamiltonians.py` provides the constructors; what is missing is the sweep
+helper (build H per field/η value, collect `eigenenergies()`) and the plots.
+
+### 3.5 EFG direction quiver maps (`archive/quadrupolar/plotting_QI_direction.py`)
+
+`qdot/plot.py` has no quiver function at all. The archive draws the EFG
+principal-axis direction at each site (arrow angle from Euler γ, optionally
+scaled by V_ZZ) over a choice of backgrounds:
+
+- biaxiality η heatmap;
+- In concentration heatmap;
+- quadrupole frequency magnitude heatmap (single species and 2×2 all-species
+  grid with a shared colour scale);
+- a two-panel Checkhovich vs Sundfors comparison with a shared colorbar.
+
+### 3.6 Quadrupolar statistics: heatmaps and histograms (`quadrupolar_strength_maps.py`, `energy_histograms.py`)
+
+- Spatial heatmaps of quadrupole frequency K·V_ZZ and of η (fixed 0–1 scale).
+  qdot's `plot_equivalent_b_field` is the same imshow pattern but no dedicated
+  maps exist, and the **computation** of the equivalent-B-field array — the
+  partner to qdot's existing plotters — was never ported either
+  (`equivalent_B_field_calculation` in `correlator_calc.py`).
+- Histograms of per-site quadrupole frequencies with fitted distributions
+  (Gaussian, Maxwell-Boltzmann, gamma), per species and 2×2 all-species grids,
+  with fit parameters annotated on the figure and an `.npz` cache layer.
+- Layered comparisons: all species in one plot; multiple regions distinguished
+  by linestyle; Checkhovich vs Sundfors comparison limited to the two species
+  whose GET values changed (Ga69, As75).
+
+### 3.7 Measured (Sokolov) strain plotting (`archive/strain/strain_grapher.py`)
+
+qdot can load the Sokolov strain data but cannot plot it.
+`plot_strain_tensors` only accepts the toy model's (n, m, 2, 2) tensor array
+with xx/xy/yy components. The archive has:
+
+- `sokolov_strain_grapher` / `sokolov_strain_vertical_grapher` — the
+  paper-recreation figures: three panels (ε_xx, ε_zz, ε_xz), horizontal with
+  fixed ±0.02 scale or vertical with a shared data-driven RdBu scale.
+- `strain_histograms` — shear strain distribution under two definitions.
+- `single_row_strain_grapher` — line cut of all three components along a row.
+- `many_rows_strain_grapher_3d` — 3D surface of one component (low value).
+- `finding_atomic_sites` — peak detection over the strain map via
+  `skimage.feature.peak_local_max` (only archive code needing scikit-image).
+
+### 3.8 Mirrored (symmetric) dataset support
+
+qdot has `load_mirrored_data` for strain but:
+
+- the **creation** functions are missing (`create_mirrored_data.py`):
+  `mirror_array_left_to_right`/`right_to_left` and the four writers that save
+  mirrored strain `.npz` and mirrored concentration `.npy` files — without
+  them `load_mirrored_data` only works on files produced by the archive;
+- there is no loader for mirrored **concentration** data at all;
+- `absorption_spectrum` does not pass `real_strain`/`mirror_type` through to
+  `load_efg`, so NMR on mirrored datasets is not reachable through qdot even
+  though `load_efg` itself supports the flags.
+
+### 3.9 Concentration dataset creation (`archive/concentration/`)
+
+`create_nice_conc_dataset.py` builds the file every concentration loader
+depends on: it reads the raw Sokolov `.mat` scatter data (15,011 points),
+clips negatives, grids it onto the 1600×1600 strain-pixel grid with
+`scipy.interpolate.griddata` (cubic), and writes
+`conc_data_to_scale_cubic_interpolation.npy`.
+`recreate_sokolov_conc_graphs.py` renders the nearest/linear/cubic variants
+for comparison against the published figure. qdot only consumes the finished
+`.npy`. Also unported: `region_bound_finder`, which converts a rectangle drawn
+on the concentration map into `region_bounds` for the other functions, and the
+named-region catalogue `QD_regions_dict` (nine named pixel regions such as
+`entire_dot`, `central_high_In`) — qdot has only the single
+`SOKOLOV_DOT_REGION` constant.
+
+### 3.10 Machine gun: density-matrix formulation with error channels (`density_matrix_machine_gun.py`)
+
+`qdot/machine_gun.py` covers only the ideal state-vector protocol; its unused
+scaffolding (`state_to_density_matrix`, `cnot_array`) was written for this
+extension. Missing:
+
+- `PerfectMachineGunDensityMatrices` — ideal protocol on vectorised ρ via
+  superoperators;
+- `DotDephasingKrausKreator` / `DotDampingKrausKreator` — phase-damping and
+  amplitude-damping Kraus pairs on the dot qubit, embedded into the full
+  (n_photons+1)-qubit space;
+- `DephasingMachineGun` / `AmplitudeDampingMachineGun` — protocol runs with
+  the error channel applied each cycle;
+- the analysis/figure family: fidelity and trace-distance vs error strength,
+  multi-photon-count overlays, combined fidelity+trace-distance figures, a 2D
+  (photon count × dephasing) fidelity heatmap, and a tabulation of maximal
+  dephasing fidelity against candidate analytic scalings;
+- `ErrorWrapper` — converts the readable `[[photon, "X"], ...]` error list
+  into the numeric array `machine_gun_with_pauli_errors` takes.
+
+### 3.11 NFF: small gaps
+
+- X and Y polarisation finders (qdot has Z only).
+- No plotting function for the dephasing polarisation curve (the archive plots
+  it in a module-level script; `qdot/plot.py` has no NFF figure).
+- `phase_damping_graph.py` — the analytic γ vs photon-scattering-probability
+  relation.
+- `NFF_no_nuclear_spin_steady_state.py` — closed-form 4×4 process matrix for
+  one pulse-plus-precession cycle (Greilich 2007 parameters) and a scan for
+  eigenvalue-1 steady states over (q0, φ). Print-only in the archive.
+
+### 3.12 Correlator: minor gaps
+
+The computation and plots are ported. Missing: a load-and-plot helper for the
+`.npz` archives that `run_log_correlator_simulation` /
+`run_linear_correlator_simulation` write, and the batch drivers that loop
+calculation + figures over a list of B fields.
 
 ---
 
-### Energy level diagrams (`archive/quadrupolar/splitting_graphs.py`)
+## 4. Not worth porting
 
-This entire category is absent from `qdot`. The archive has functions to:
+Scratch, superseded, or one-off code; listed so future reviews don't rediscover it:
 
-- `single_field_energy_levels` / `many_fields_energy_levels_calc` — compute eigenstate
-  energies (in MHz) for a real lattice site as the applied field is swept from 0 to
-  some maximum, in either Faraday or Voigt geometry.
-- `single_eta_energy_levels` / `many_eta_energy_levels_calc` — same sweep but over
-  biaxiality η rather than B field, useful for understanding the quadrupolar effect in
-  isolation.
-- `plot_energy_level_diagram` / `plot_and_save_all_species_EL_diagrams` — anti-crossing
-  energy level plots, one curve per eigenstate, for all four species.
-- `all_sites_energy_level_diagram` / `random_sites_energy_level_diagram` — overlay
-  energy levels from many sites to show the spread due to inhomogeneous strain.
-- `random_sites_geometry_comparison_EL_diagram` — Faraday and Voigt side-by-side on
-  the same axes.
-
-`qdot/hamiltonians.py` provides the Hamiltonians these functions build on, but there
-is no function in `qdot` that diagonalises them over a parameter sweep and returns or
-plots the eigenvalue trajectories.
+| Item | Reason |
+|---|---|
+| `errors_testing.py`, `CNOT_testing.py`, `perfect_machine_gun_testing.py`, `single_qubit_operation_testing.py` | debug duplicates of ported functions with print statements |
+| `correlator/testing_functions.py` | scrapbook with undefined references; the chunksize/step-size benchmarks belong in `benchmarks/` if ever needed |
+| `edge_counting_test.py`, `toy_model_timer.py` | verify things now covered by tests; timing harness trivial to rewrite |
+| `tersoff_cutoff_func_test.py` | explores a Tersoff potential never adopted by the model |
+| `changing_eigen_vectors_test.py`, `ratio_of_QI_strengths.py` | scratch; the latter is a self-contained analytic curiosity (xkcd-styled plot) |
+| `comparing_sokolov_and_checkhovich_QI_graphs.py` | marked outdated in-file (2020); superseded by `use_sundfors` + the quiver plots |
+| `realistic_ham_testing.py` Hinton diagrams and console dumps | collaborator one-offs (`EigenvalueDataforDara`); the eigenvector-overlap sweep figures are the only candidate worth reconsidering later |
+| `spectra.py` module-level "control panel" boolean blocks | replaced by `examples/` scripts in qdot's structure |
+| Duplicate loaders in `conc_maps.py`, `create_mirrored_data.py` | already consolidated in `qdot/io.py` |
 
 ---
 
-### Quadrupolar interaction visualisation (`archive/quadrupolar/`)
+## 5. Porting plan
 
-**`quadrupolar_strength_maps.py`**
-- `quadrupolar_interaction_strength_plotter` — computes the quadrupolar frequency
-  K·V_ZZ at every site in the dot region and plots a 2D heatmap. Highlights where
-  the quadrupolar interaction is strongest.
-- `biaxiality_plotter` — 2D heatmap of η, with optional overlay of the Sundfors vs.
-  Checkhovich difference.
+Ordered by value per unit of effort. Each phase is a self-contained PR-sized
+unit with tests; plotting functions follow `qdot/plot.py` conventions (return
+the Figure, `save_path` to save instead of show). All cache files take an
+explicit directory argument and reuse the `save_efg` pattern (skip-with-warning
+unless `overwrite=True`).
 
-**`plotting_QI_direction.py`**
-- `plot_arrows_with_biax_background` — quiver plot of the EFG principal-axis direction
-  at each site, overlaid on an η heatmap. Shows where the EFG points across the dot.
-- `comparison_plot_with_biax_background` — side-by-side Sundfors vs. Checkhovich
-  quiver comparison using a shared axis grid.
-- `plot_arrows_with_conc_background` — same quiver plot with In concentration as
-  background instead of η.
-- `plot_arrows_with_strength_background` / `plot_arrows_with_strength_background_all_species`
-  — quiver plots with quadrupolar frequency magnitude as background, all four species
-  in a 2×2 grid.
+### Phase 1 — NMR multi-site engine and maps (highest value)
 
-None of these appear in `qdot/plot.py`, which has heatmap and correlator FFT plotting
-but no quiver or vector-field visualisation.
+The largest experimental capability gap. Target: reproduce
+`many_location_parallel_calculation` → `NMR_plot` end to end.
+
+New in `qdot/nmr.py`:
+
+```python
+def summed_absorption_spectrum(nuclear_species, applied_field, field_geometry,
+                               rf_freq_list, locations, data_dir, *,
+                               region_bounds=None, step_size=1, rf_field=5e-3,
+                               use_sundfors=False, n_processes=None) -> np.ndarray
+    # Pool.starmap over locations (pattern from run_correlator_series),
+    # summed over sites. One row of the 2D map.
+
+def absorption_map(nuclear_species, applied_field_list, field_geometry,
+                   rf_freq_list, locations, data_dir, ...) -> np.ndarray
+    # (n_fields, n_freqs); loops summed_absorption_spectrum over fields,
+    # loading EFG data once.
+```
+
+New in `qdot/io.py`: `save_nmr_map` / `load_nmr_map` with a parameter-encoded
+filename (species, geometry, n_locs, bounds, field and frequency grids), and a
+`SOKOLOV_REGIONS` dict porting `QD_regions_dict` (keep `SOKOLOV_DOT_REGION` as
+an alias for the `entire_dot` entry).
+
+New site-sampling helpers (in `qdot/nmr.py` or a small `qdot/sites.py`):
+`random_locations(n, region_bounds, shape_source)`, `all_locations(...)`, and
+`find_best_locations(...)` (strain-local-maximum snap; the "summed strain
+components" metric should be flagged to the physicist before relying on it).
+
+New in `qdot/plot.py`: `plot_nmr_map` (log-scaled imshow, MHz × T extents),
+`plot_nmr_map_pair` (two-panel side-by-side, used for both Faraday|Voigt and
+Checkhovich|Sundfors), `plot_nmr_map_difference` (diverging colormap; covers
+both comparison figures via arguments rather than four near-identical
+functions).
+
+Also in this phase: pass `real_strain`/`mirror_type` through
+`absorption_spectrum` and `varied_field_spectra` (one-line plumbing that
+unblocks mirrored-dot NMR).
+
+Effort: the largest phase — engine + io + three plot functions + tests.
+Tests can run on tiny synthetic EFG archives as `tests/test_nmr.py` already does.
+
+### Phase 2 — Energy-level diagrams
+
+New in `qdot/hamiltonians.py` (or a new `qdot/levels.py` if hamiltonians.py
+should stay constructor-only):
+
+```python
+def energy_levels_vs_field(applied_fields, eta, V_ZZ, euler_angles,
+                           nuclear_species, field_geometry) -> np.ndarray  # (n_levels, n_fields)
+def energy_levels_vs_eta(etas, applied_field, V_ZZ, euler_angles, ...) -> np.ndarray
+```
+
+taking site parameters directly (callers fetch them via `load_efg`), so the
+functions stay decoupled from the archive format. New in `qdot/plot.py`:
+`plot_energy_levels` (single panel) and `plot_energy_levels_comparison`
+(two-panel Faraday|Voigt with shared y-limits). Ensemble (all-sites /
+random-sites) figures fall out by looping the sweep and overplotting — provide
+this as an example script rather than a library function.
+
+Effort: small. The physics is three lines per sweep point.
+
+### Phase 3 — Quadrupolar maps, quiver plots, and histograms
+
+Computation side:
+
+- factor the quadrupole coupling constant `3eQ/(2hI(2I−1))` — currently
+  duplicated in `correlators.py` and `nmr.py` — into a function in
+  `qdot/isotopes.py` (e.g. `quadrupole_coupling(species_dict_entry)`), and add
+  `quadrupole_frequency_map(nuclear_species, V_ZZ)` and
+  `equivalent_b_field(nuclear_species, V_ZZ)` (the missing partner to the
+  existing plotters) somewhere appropriate (`qdot/efg.py`).
+
+Plot side (`qdot/plot.py`):
+
+- `plot_site_map(array, ...)` — the generic imshow+colorbar pattern used by
+  η maps, frequency maps, and the existing equivalent-B-field plots; dedicated
+  thin wrappers `plot_biaxiality` and `plot_quadrupole_frequency` for the
+  standard colour scales (η fixed 0–1).
+- `plot_efg_directions(euler_angles, background, ...)` — the quiver overlay
+  with a background array argument instead of three near-copies; an
+  `all_species` 2×2 variant with shared normalisation.
+- `plot_frequency_histogram(frequencies, fit="gamma"|"maxwell"|"gauss"|None)`
+  — step histogram with optional fitted pdf and annotated fit parameters;
+  `plot_frequency_histograms_grid` (2×2 all species);
+  layered overlays accept a list of (label, frequencies) pairs, covering both
+  the multi-region and Checkhovich-vs-Sundfors comparisons with one function.
+
+The histogram `.npz` cache from the archive is probably unnecessary once the
+inputs come from already-cached EFG archives; drop it unless the physicist
+wants it.
+
+Effort: moderate; all plotting, no new physics. The distribution-fitting
+choice (which distributions are meaningful) is a physics question — port all
+three fits, let the physicist prune.
+
+### Phase 4 — Sokolov strain plots and mirrored datasets
+
+- `plot_measured_strain(xx, xz, zz, layout="horizontal"|"vertical", ...)` in
+  `qdot/plot.py` covering both paper-recreation figures (fixed ±0.02 scale
+  horizontal; shared RdBu scale vertical); `plot_strain_row_cut`; the shear
+  histogram folds into the Phase 3 histogram function. Skip the 3D surface and
+  `finding_atomic_sites` (scikit-image dependency, exploratory) unless asked.
+- `qdot/io.py`: `mirror_array(array, direction)`,
+  `create_mirrored_strain_data(data_dir, region_bounds, direction)`,
+  `create_mirrored_concentration_data(...)`,
+  `load_mirrored_concentration_data(...)` — completing the mirrored pipeline
+  whose loader already exists.
+
+Effort: small-moderate.
+
+### Phase 5 — Experimental NMR simulation and pulse analysis
+
+Builds on Phase 1.
+
+- `experimental_nmr_simulation(...)` in `qdot/nmr.py`: species populations from
+  the concentration map, per-species `absorption_map`, returns the per-species
+  maps so the caller chooses summed or layered rendering;
+  `plot_nmr_map_layered` in `qdot/plot.py` (Greys/Blues/Reds, decreasing alpha).
+  **Blocked on a physics decision:** the 50%-As/concentration-split site
+  heuristic should be confirmed (add to `human-todo.` when the port starts).
+- Combined-species spectrum + pulse selectivity: `combined_spectrum(...)`
+  (all four species summed over shared sites), `lorentzian_pulse(freqs, centre,
+  width)`, `pulse_capture_fraction(spectrum, pulse, windows)` (Simpson
+  integration), and plots for the peak-marked spectrum and pulse-width sweep.
+  The hardcoded target windows (77.8–82.3 MHz etc.) become arguments.
+
+Effort: moderate, mostly plumbing once Phase 1 exists.
+
+### Phase 6 — Machine gun density-matrix extension
+
+Completes what `qdot/machine_gun.py`'s docstring already promises:
+
+```python
+def initial_density_matrix(n_photons) -> qutip.Qobj
+def dot_dephasing_superoperator(dephasing, n_photons) -> qutip.Qobj
+def dot_damping_superoperator(damping, n_photons) -> qutip.Qobj
+def perfect_machine_gun_density_matrix(n_photons) -> qutip.Qobj
+def noisy_machine_gun(n_photons, channel, strength) -> qutip.Qobj   # dephasing | damping
+def error_list_to_array(errors: list) -> np.ndarray                  # ErrorWrapper
+```
+
+plus fidelity/trace-distance sweep helpers returning arrays, and one plot
+function for metric-vs-error-strength curves (multi-photon-count overlay).
+The existing `cnot_array` and `state_to_density_matrix` scaffolding gets used.
+Note the archive's analytic-scaling tabulation (`MaximumDephasingFidelityTest`)
+is analysis, not library code — example script material.
+
+Effort: moderate; Kraus embedding needs care, and tests should check channel
+trace preservation and the perfect-channel limit against the state-vector path.
+
+### Phase 7 — One-time dataset tooling and NFF extras (lowest priority)
+
+- Concentration dataset creation from the Sokolov `.mat` (`scripts/` or an
+  example, not the library — it runs once per dataset): clip, `griddata`
+  interpolation, method-comparison figures. Requires the raw `.mat` file,
+  which is not in the repo — confirm it still exists before porting.
+- `region_bound_finder` (rectangle → region_bounds converter) alongside
+  `SOKOLOV_REGIONS` in `qdot/io.py`.
+- NFF: `x_polarisation`/`y_polarisation`, `plot_polarisation_curve`, the γ vs
+  scattering-probability relation, and (optionally, as an example) the
+  steady-state process-matrix scan with a real figure instead of the archive's
+  print-only output.
+- Correlator: `load_correlator_archive(...)` + batch plot driver for the
+  multi-field figure sets.
 
 ---
 
-### Machine gun error channels (`archive/machine_gun/density_matrix_machine_gun.py`)
+## 6. Physics questions raised by the port (for human-todo. when work starts)
 
-`qdot/machine_gun.py` implements the cluster-state machine-gun (CSMG) protocol using
-state vectors and unitary operators. The archive has a parallel density-matrix
-formulation using QuTiP superoperators that is entirely absent from `qdot`:
-
-- `DotDephasingKrausKreator` — builds the dephasing superoperator from Kraus operators.
-- `DotDampingKrausKreator` — builds the amplitude-damping superoperator.
-- `DephasingMachineGun` — runs the CSMG protocol with a dephasing error channel
-  applied at each step.
-- `AmplitudeDampingMachineGun` — same with amplitude damping.
-- `PerfectMachineGunDensityMatrices` — density-matrix version of the ideal (error-free)
-  protocol, using QuTiP's `spre`/`spost` superoperator infrastructure.
-
-The practical consequence is that `qdot` can only simulate the ideal CSMG and cannot
-model the effect of photon loss or pure dephasing noise on the output state.
-
----
-
-### Symmetric dot datasets (`archive/mirrored_dots/create_mirrored_data.py`)
-
-`qdot/io.py` has `load_mirrored_data` to read pre-made symmetric datasets, but the
-creation functions that produce those files are not ported:
-
-- `mirror_array_left_to_right` / `mirror_array_right_to_left` — reflect a strain or
-  concentration array about its centre column.
-- `create_left_right_strain_data` / `create_right_left_strain_data` — applies the
-  mirror, packages all three strain components, and saves to `.npz`.
-- `create_left_right_conc_data` / `create_right_left_conc_data` — same for the
-  In115 concentration map.
-
-Without these, `load_mirrored_data` can only be used if the files already exist from
-a previous run of the archive scripts.
-
----
-
-## What was ported with significant interface changes
-
-| Archive function | `qdot` equivalent | Key difference |
-|---|---|---|
-| `calculate_EFG` (nested Python loops) | `calculate_efg` + `calculate_efg_vectorised` | Vectorised via batched NumPy; Euler angle sign-convention differences documented |
-| `one_species_time_series_correlator_calculator` | `run_correlator_series` | Returns array directly; does not save to disk |
-| `log_spaced_correlator_simulation` | `run_log_correlator_simulation` | Saves all species in one `.npz`; same structure |
-| `calculate_absorbtion_single_slice_data` | `absorption_spectrum` | Takes explicit `data_dir`; no global paths; step_size defaults to 1 |
-| `varied_B_field_spectra` | `varied_field_spectra` | Returns list of dicts rather than writing files |
-| `phase_damping_polarisation` (NFF) | `dephasing_polarisation_curve` | Split into computation and plotting |
-| Strain toy model | `run_strain_simulation` | Vectorised energy and tensor; returns tuple not separate variables |
-| `EFG_data_creator` | `calculate_efg` + `save_efg` | Separated into two explicit calls |
-
----
-
-## Priority assessment
-
-The gaps vary significantly in how useful they would be to port:
-
-**High value, moderate effort:**
-- Multi-site parallel NMR + 2D absorption heatmap (`experimental_NMR_sim` pattern) —
-  directly comparable to experimental data; the architecture already exists in the
-  correlator module.
-- FFT of correlator + spectral density plots — connects time-domain results to
-  frequency-domain measurements.
-
-**Moderate value, moderate effort:**
-- Energy level diagrams — useful for understanding individual sites; straightforward
-  given existing Hamiltonian functions.
-- Mirrored dataset creation — needed to make `load_mirrored_data` independently usable.
-
-**High effort, specialist use:**
-- Density-matrix machine gun with error channels — requires QuTiP superoperator
-  infrastructure; only needed for noise modelling studies.
-- EFG direction quiver plots — visualisation detail; useful for papers but not
-  core computation.
+- Species-split heuristic in `experimental_NMR_sim` (As fixed at 50%).
+- `find_best_locations` ranks sites by ε_xx + ε_xz + ε_zz — is a plain sum the
+  right strain metric?
+- Which distribution fits (Gaussian / Maxwell / gamma) of the quadrupole
+  frequency histograms are physically meaningful.
+- Whether archive figures that depend on the corrected NFF/transition-rate
+  physics should be regenerated for comparison before the archive is retired.

--- a/human-todo.
+++ b/human-todo.
@@ -29,6 +29,22 @@ In `qdot/isotopes.py`, the `old_species_dict` entries look suspect against the c
 
 Please check S11/S44 for all four species against Sundfors (1974) and correct `old_species_dict` if needed.
 
+## Experimental NMR simulation — species population heuristic
+
+`qdot.nmr.experimental_nmr_simulation` (ported from the archive's `experimental_NMR_sim`) splits the sampled sites as: In115 in proportion to the mean In concentration, As75 fixed at 50% (`arsenic_fraction` parameter), the remainder Ga69, with Ga71 excluded entirely ("only including Ga69 to begin with" in the original). Confirm or refine this heuristic — in particular whether Ga71 should be included at its natural abundance (~40% of Ga) and whether the As fraction should account for the cation/anion sublattice structure.
+
+## find_best_locations — strain metric
+
+`qdot.sites.find_best_locations` ranks sites by the plain component sum ε_xx + ε_xz + ε_zz (inherited from `random_point_searcher.py`). Signs can cancel and the trace-plus-shear combination has no obvious physical meaning. Decide whether a better metric (e.g. |K·V_ZZ|, or the EFG magnitude itself) should replace it.
+
+## Quadrupole frequency histograms — which distribution fits are meaningful
+
+`qdot.plot.plot_frequency_histogram` ports all three fits from the archive (Gaussian on signed frequencies; Maxwell-Boltzmann and gamma on magnitudes). Decide which are physically meaningful for the dot's frequency distribution and prune the rest.
+
+## NFF x/y polarisation — basis convention
+
+`qdot.nff.z_polarisation` measures Z via σx ("Z in the X basis"), but the archive's X/Y finders — now `x_polarisation`/`y_polarisation` — use plain σx/σy with no basis rotation, so `x_polarisation` is numerically identical to `z_polarisation`. Confirm what the X/Y measurements should be in the rotated frame and adjust the operators if needed.
+
 ## Spin correlator time evolution — factor of 2π?
 
 `qdot/correlators.py` `spin_correlator` evolves with `exp(±i·t·H)` where H is built from frequencies in Hz (`zeeman_frequency_per_tesla`, quadrupolar coupling in Hz). If those are ordinary (cyclic) frequencies, the propagator should be `exp(±i·2π·f·t)`, i.e. a 2π is missing and all correlator timescales are stretched by 2π. If the stored values are meant as angular frequencies, the docstrings saying "Hz" should be corrected instead. Needs a decision on the intended convention; not changed in code since it rescales all published-comparison timescales.

--- a/qdot/__init__.py
+++ b/qdot/__init__.py
@@ -1,11 +1,19 @@
-from qdot.isotopes import species_dict, old_species_dict
-from qdot.efg import calculate_efg, calculate_efg_vectorised, euler_angles_from_rot_mat
+from qdot.isotopes import species_dict, old_species_dict, quadrupole_coupling
+from qdot.efg import (
+    calculate_efg,
+    calculate_efg_vectorised,
+    euler_angles_from_rot_mat,
+    quadrupole_frequency,
+    equivalent_b_field,
+)
 from qdot.hamiltonians import (
     spin_rotator,
     faraday_hamiltonian,
     voigt_hamiltonian,
     rf_hamiltonian,
     transition_rate,
+    energy_levels_vs_field,
+    energy_levels_vs_eta,
 )
 from qdot.correlators import (
     spin_correlator,
@@ -13,6 +21,7 @@ from qdot.correlators import (
     run_correlator_series,
     run_log_correlator_simulation,
     run_linear_correlator_simulation,
+    load_correlator_archive,
 )
 from qdot.io import (
     load_strain_data,
@@ -20,42 +29,100 @@ from qdot.io import (
     load_efg,
     save_efg,
     load_concentration_data,
+    load_mirrored_concentration_data,
+    create_mirrored_strain_data,
+    create_mirrored_concentration_data,
+    mirror_array,
+    save_nmr_map,
+    load_nmr_map,
+    region_from_rectangle,
     SOKOLOV_DOT_REGION,
+    SOKOLOV_REGIONS,
 )
-from qdot.nmr import absorption_spectrum, varied_field_spectra
+from qdot.sites import all_locations, random_locations, find_best_locations
+from qdot.nmr import (
+    absorption_spectrum,
+    varied_field_spectra,
+    absorption_map,
+    summed_absorption_spectrum,
+    experimental_nmr_simulation,
+    combined_spectrum,
+    lorentzian_pulse,
+    pulse_capture_fraction,
+)
 from qdot.strain import run_strain_simulation, strain_tensor, strain_tensor_vectorised
-from qdot.nff import dephasing_polarisation_curve, non_dephased_polarisation
+from qdot.nff import (
+    dephasing_polarisation_curve,
+    non_dephased_polarisation,
+    x_polarisation,
+    y_polarisation,
+    dephasing_from_scattering,
+)
+from qdot.machine_gun import (
+    initial_density_matrix,
+    perfect_machine_gun_density_matrix,
+    noisy_machine_gun,
+    dot_dephasing_superoperator,
+    dot_damping_superoperator,
+    fidelity_vs_error,
+    trace_distance_vs_error,
+    error_list_to_array,
+)
 
 __all__ = [
     # isotopes
     "species_dict",
     "old_species_dict",
+    "quadrupole_coupling",
     # efg
     "calculate_efg",
     "calculate_efg_vectorised",
     "euler_angles_from_rot_mat",
+    "quadrupole_frequency",
+    "equivalent_b_field",
     # hamiltonians
     "spin_rotator",
     "faraday_hamiltonian",
     "voigt_hamiltonian",
     "rf_hamiltonian",
     "transition_rate",
+    "energy_levels_vs_field",
+    "energy_levels_vs_eta",
     # correlators
     "spin_correlator",
     "site_correlator",
     "run_correlator_series",
     "run_log_correlator_simulation",
     "run_linear_correlator_simulation",
+    "load_correlator_archive",
     # io
     "load_strain_data",
     "load_mirrored_data",
     "load_efg",
     "save_efg",
     "load_concentration_data",
+    "load_mirrored_concentration_data",
+    "create_mirrored_strain_data",
+    "create_mirrored_concentration_data",
+    "mirror_array",
+    "save_nmr_map",
+    "load_nmr_map",
+    "region_from_rectangle",
     "SOKOLOV_DOT_REGION",
+    "SOKOLOV_REGIONS",
+    # sites
+    "all_locations",
+    "random_locations",
+    "find_best_locations",
     # nmr
     "absorption_spectrum",
     "varied_field_spectra",
+    "absorption_map",
+    "summed_absorption_spectrum",
+    "experimental_nmr_simulation",
+    "combined_spectrum",
+    "lorentzian_pulse",
+    "pulse_capture_fraction",
     # strain
     "run_strain_simulation",
     "strain_tensor",
@@ -63,4 +130,16 @@ __all__ = [
     # nff
     "dephasing_polarisation_curve",
     "non_dephased_polarisation",
+    "x_polarisation",
+    "y_polarisation",
+    "dephasing_from_scattering",
+    # machine gun
+    "initial_density_matrix",
+    "perfect_machine_gun_density_matrix",
+    "noisy_machine_gun",
+    "dot_dephasing_superoperator",
+    "dot_damping_superoperator",
+    "fidelity_vs_error",
+    "trace_distance_vs_error",
+    "error_list_to_array",
 ]

--- a/qdot/correlators.py
+++ b/qdot/correlators.py
@@ -14,9 +14,8 @@ import multiprocessing
 import pathlib
 import numpy as np
 import qutip
-import scipy.constants as const
 
-from qdot.isotopes import species_dict
+from qdot.isotopes import species_dict, quadrupole_coupling
 from qdot.hamiltonians import faraday_hamiltonian
 from qdot.io import load_efg, SOKOLOV_DOT_REGION
 
@@ -138,9 +137,7 @@ def _load_site_params(
 
     species = species_dict[nuclear_species]
     spin = species["particle_spin"]
-    Q = species["quadrupole_moment"]
-    h, e = const.h, const.e
-    qcc = (3 * e * Q) / (2 * h * spin * (2 * spin - 1))
+    qcc = quadrupole_coupling(species)
 
     return {
         "n_sites": eta.size,
@@ -353,3 +350,26 @@ def run_linear_correlator_simulation(
         chunksize,
         archive_name,
     )
+
+
+def load_correlator_archive(path: pathlib.Path | str) -> dict:
+    """
+    Load a correlator archive written by run_log_correlator_simulation or
+    run_linear_correlator_simulation.
+
+    Args:
+        path: Full path to the .npz archive.
+
+    Returns:
+        dict with keys:
+            "timerange" (ndarray): Times in seconds.
+            "region_bounds" (ndarray): [left, right, top, bottom].
+            "data" (dict): Species name → correlator array, shape (3, n_times).
+    """
+    archive = np.load(path)
+    species_list = ["Ga69", "Ga71", "As75", "In115"]
+    return {
+        "timerange": archive["timerange"],
+        "region_bounds": archive["region_bounds"],
+        "data": {s: archive[f"{s}_data"] for s in species_list},
+    }

--- a/qdot/efg.py
+++ b/qdot/efg.py
@@ -6,9 +6,46 @@ the gradient-elastic tensor components S11 and S44 for each nuclear species.
 """
 
 import numpy as np
-from qdot.isotopes import species_dict, old_species_dict
+from qdot.isotopes import species_dict, old_species_dict, quadrupole_coupling
 
 _VALID_SPECIES = frozenset(species_dict)
+
+
+def quadrupole_frequency(nuclear_species: str, V_ZZ: np.ndarray) -> np.ndarray:
+    """
+    Quadrupolar frequency K·V_ZZ at each site.
+
+    Args:
+        nuclear_species (str): One of "Ga69", "Ga71", "As75", "In115".
+        V_ZZ (ndarray or float): Principal EFG component(s) in V·m⁻².
+
+    Returns:
+        ndarray or float: Quadrupolar frequency in Hz, same shape as V_ZZ.
+    """
+    if nuclear_species not in _VALID_SPECIES:
+        raise ValueError(
+            f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}"
+        )
+    return quadrupole_coupling(species_dict[nuclear_species]) * V_ZZ
+
+
+def equivalent_b_field(nuclear_species: str, V_ZZ: np.ndarray) -> np.ndarray:
+    """
+    Magnetic field giving the same level splitting as the quadrupolar interaction.
+
+    Computed as the quadrupolar frequency divided by the species' Zeeman
+    frequency per Tesla; shows the size of the quadrupolar interaction each
+    nucleus experiences in field units.
+
+    Args:
+        nuclear_species (str): One of "Ga69", "Ga71", "As75", "In115".
+        V_ZZ (ndarray or float): Principal EFG component(s) in V·m⁻².
+
+    Returns:
+        ndarray or float: Equivalent magnetic field in Tesla, same shape as V_ZZ.
+    """
+    freq = quadrupole_frequency(nuclear_species, V_ZZ)
+    return freq / species_dict[nuclear_species]["zeeman_frequency_per_tesla"]
 
 
 def euler_angles_from_rot_mat(rot_mat: np.ndarray) -> tuple[float, float, float]:

--- a/qdot/hamiltonians.py
+++ b/qdot/hamiltonians.py
@@ -8,6 +8,8 @@ the Zeeman and quadrupolar terms should be passed in the same units.
 import numpy as np
 import qutip
 
+from qdot.isotopes import species_dict, quadrupole_coupling
+
 
 def spin_rotator(
     alpha: float, beta: float, gamma: float, initial_spin: qutip.Qobj
@@ -202,3 +204,108 @@ def transition_rate(
     prob = np.abs(mixing_hamiltonian.matrix_element(final_state, init_state)) ** 2
     lorentzian = (2 * delta) / ((E_final - E_init - omega_rf) ** 2 + delta**2)
     return np.real_if_close(prob * lorentzian)
+
+
+def energy_levels_vs_field(
+    nuclear_species: str,
+    applied_fields: np.ndarray,
+    biaxiality: float,
+    V_ZZ: float,
+    euler_angles: tuple[float, float, float],
+    field_geometry: str = "Faraday",
+) -> np.ndarray:
+    """
+    Eigenenergies of the nuclear spin Hamiltonian swept over applied field.
+
+    Builds the Zeeman + quadrupolar Hamiltonian for one site at each field in
+    applied_fields and collects the sorted eigenenergies, producing the data
+    for an anti-crossing energy level diagram.
+
+    Args:
+        nuclear_species (str): One of "Ga69", "Ga71", "As75", "In115".
+        applied_fields (ndarray): Magnetic fields to sweep, in Tesla.
+        biaxiality (float): EFG biaxiality η at the site.
+        V_ZZ (float): Principal EFG component at the site (V·m⁻²).
+        euler_angles (tuple): (alpha, beta, gamma) to the PAF, in radians.
+        field_geometry (str): "Faraday" or "Voigt".
+
+    Returns:
+        ndarray: Eigenenergies in Hz, shape (n_levels, n_fields).
+    """
+    species = species_dict[nuclear_species]
+    spin = species["particle_spin"]
+    quadrupolar_term = quadrupole_coupling(species) * V_ZZ
+    alpha, beta, gamma = euler_angles
+
+    constructor = _geometry_constructor(field_geometry)
+
+    n_levels = int(2 * spin + 1)
+    levels = np.zeros((n_levels, len(applied_fields)))
+    for i, field in enumerate(applied_fields):
+        H = constructor(
+            species["zeeman_frequency_per_tesla"] * field,
+            quadrupolar_term,
+            biaxiality,
+            spin,
+            alpha,
+            beta,
+            gamma,
+        ).tidyup()
+        # H is Hermitian; rounding can leave negligible imaginary parts.
+        levels[:, i] = np.real(np.real_if_close(H.eigenenergies()))
+    return levels
+
+
+def energy_levels_vs_eta(
+    nuclear_species: str,
+    eta_values: np.ndarray,
+    applied_field: float = 0.0,
+    V_ZZ: float = 5e20,
+    euler_angles: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    field_geometry: str = "Faraday",
+) -> np.ndarray:
+    """
+    Eigenenergies of the nuclear spin Hamiltonian swept over biaxiality η.
+
+    Useful for understanding the quadrupolar interaction in isolation
+    (applied_field defaults to 0). The default V_ZZ of 5e20 V·m⁻² is
+    approximately the mean over the Sokolov dot region.
+
+    Args:
+        nuclear_species (str): One of "Ga69", "Ga71", "As75", "In115".
+        eta_values (ndarray): Biaxiality values to sweep.
+        applied_field (float): Static magnetic field in Tesla. Default 0.
+        V_ZZ (float): Principal EFG component (V·m⁻²).
+        euler_angles (tuple): (alpha, beta, gamma) to the PAF, in radians.
+        field_geometry (str): "Faraday" or "Voigt".
+
+    Returns:
+        ndarray: Eigenenergies in Hz, shape (n_levels, n_eta).
+    """
+    species = species_dict[nuclear_species]
+    spin = species["particle_spin"]
+    quadrupolar_term = quadrupole_coupling(species) * V_ZZ
+    zeeman_term = species["zeeman_frequency_per_tesla"] * applied_field
+    alpha, beta, gamma = euler_angles
+
+    constructor = _geometry_constructor(field_geometry)
+
+    n_levels = int(2 * spin + 1)
+    levels = np.zeros((n_levels, len(eta_values)))
+    for i, eta in enumerate(eta_values):
+        H = constructor(
+            zeeman_term, quadrupolar_term, eta, spin, alpha, beta, gamma
+        ).tidyup()
+        levels[:, i] = np.real(np.real_if_close(H.eigenenergies()))
+    return levels
+
+
+def _geometry_constructor(field_geometry: str):
+    """Map a geometry name onto the corresponding Hamiltonian constructor."""
+    if field_geometry == "Faraday":
+        return faraday_hamiltonian
+    if field_geometry == "Voigt":
+        return voigt_hamiltonian
+    raise ValueError(
+        f"field_geometry must be 'Faraday' or 'Voigt', got {field_geometry!r}"
+    )

--- a/qdot/io.py
+++ b/qdot/io.py
@@ -25,6 +25,44 @@ logger = logging.getLogger(__name__)
 # (Sokolov et al. DOI: 10.1103/PhysRevB.93.045301).
 SOKOLOV_DOT_REGION = [100, 1200, 439, 880]
 
+# Named pixel regions of the Sokolov dataset used throughout the original
+# research scripts. "entire_dot" is the same as SOKOLOV_DOT_REGION.
+SOKOLOV_REGIONS = {
+    "central_high_In": [450, 850, 550, 650],
+    "central_low_In": [450, 850, 660, 760],
+    "dot_LHS": [20, 420, 650, 750],
+    "dot_RHS": [1010, 1410, 650, 750],
+    "top_right_outside_dot": [1010, 1410, 450, 550],
+    "below_outside_dot": [450, 850, 775, 875],
+    "single_atom_region": [560, 575, 600, 625],
+    "entire_dot": SOKOLOV_DOT_REGION,
+    "entire_image": [100, 1200, 200, 1000],
+}
+
+
+def region_from_rectangle(
+    base_region_bounds: list[int], rectangle: list[int]
+) -> list[int]:
+    """
+    Convert a rectangle drawn on a plotted region into absolute region bounds.
+
+    Rectangles use the [left, bottom, width, height] convention of
+    plot_concentration_with_regions; imshow plots from the top-left, so
+    "bottom = 0" is at the top of the image.
+
+    Args:
+        base_region_bounds (list): [left, right, top, bottom] of the plotted region.
+        rectangle (list): [left, bottom, width, height] in region pixel coordinates.
+
+    Returns:
+        list: [left, right, top, bottom] in absolute dataset coordinates.
+    """
+    left = base_region_bounds[0] + rectangle[0]
+    right = left + rectangle[2]
+    top = base_region_bounds[2] + rectangle[1]
+    bottom = top + rectangle[3]
+    return [left, right, top, bottom]
+
 
 def load_strain_data(
     data_dir: pathlib.Path | str,
@@ -225,4 +263,264 @@ def load_efg(
         archive["V_YY"],
         archive["V_ZZ"],
         archive["euler_angles"].reshape(n_sites, 3),
+    )
+
+
+def mirror_array(data_array: np.ndarray, direction: str = "left_right") -> np.ndarray:
+    """
+    Make a 2D array symmetric by reflecting one half about the centre column.
+
+    Args:
+        data_array (ndarray): 2D array to mirror.
+        direction (str): "left_right" keeps the left half and reflects it onto
+            the right; "right_left" keeps the right half.
+
+    Returns:
+        ndarray: Symmetric array. For odd column counts the centre column is
+        dropped (the output has one column fewer than the input), matching the
+        original create_mirrored_data behaviour.
+    """
+    half = data_array.shape[1] // 2
+    if direction == "left_right":
+        kept = data_array[:, :half]
+        return np.hstack([kept, np.fliplr(kept)])
+    if direction == "right_left":
+        kept = data_array[:, data_array.shape[1] - half :]
+        return np.hstack([np.fliplr(kept), kept])
+    raise ValueError(
+        f"direction must be 'left_right' or 'right_left', got {direction!r}"
+    )
+
+
+def create_mirrored_strain_data(
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int],
+    mirror_type: str = "left_right",
+    overwrite: bool = False,
+) -> None:
+    """
+    Create and save a mirrored (synthetic, symmetric) strain dataset.
+
+    Loads the real strain data for the region (already sign-flipped to the
+    simulation convention by load_strain_data), mirrors each component about
+    the centre column, and saves the archive that load_mirrored_data reads.
+    The archive keys keep the raw-file names (full_xx_data, full_xy_data,
+    full_yy_data) for compatibility, but hold the sign-flipped xx/xz/zz values.
+
+    Args:
+        data_dir: Directory containing the strain text files; the archive is
+            written here too.
+        region_bounds (list): [left, right, top, bottom].
+        mirror_type (str): "left_right" or "right_left".
+        overwrite (bool): Replace an existing archive instead of skipping it.
+    """
+    data_dir = pathlib.Path(data_dir)
+    region_bounds = list(region_bounds)
+    path = (
+        data_dir / f"{mirror_type}_mirrored_strain_data_in_region_{region_bounds}.npz"
+    )
+    if path.exists() and not overwrite:
+        logger.warning(
+            "Mirrored strain archive already exists, not overwriting: %s", path
+        )
+        return
+
+    xx, xz, zz = load_strain_data(data_dir, region_bounds)
+    np.savez(
+        path,
+        full_xx_data=mirror_array(xx, mirror_type),
+        full_xy_data=mirror_array(xz, mirror_type),
+        full_yy_data=mirror_array(zz, mirror_type),
+    )
+    logger.info("Saved mirrored strain archive: %s", path)
+
+
+def create_mirrored_concentration_data(
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int],
+    mirror_type: str = "left_right",
+    method: str = "cubic",
+    overwrite: bool = False,
+) -> None:
+    """
+    Create and save a mirrored In115 concentration dataset.
+
+    Args:
+        data_dir: Directory containing the concentration .npy file; the
+            mirrored file is written here too.
+        region_bounds (list): [left, right, top, bottom].
+        mirror_type (str): "left_right" or "right_left".
+        method (str): Interpolation method of the source file.
+        overwrite (bool): Replace an existing file instead of skipping it.
+    """
+    data_dir = pathlib.Path(data_dir)
+    region_bounds = list(region_bounds)
+    path = (
+        data_dir / f"{mirror_type}_mirrored_In_conc_data_in_region_{region_bounds}.npy"
+    )
+    if path.exists() and not overwrite:
+        logger.warning(
+            "Mirrored concentration file already exists, not overwriting: %s", path
+        )
+        return
+
+    conc = load_concentration_data(data_dir, region_bounds, method=method)
+    np.save(path, mirror_array(conc, mirror_type))
+    logger.info("Saved mirrored concentration data: %s", path)
+
+
+def load_mirrored_concentration_data(
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int],
+    mirror_type: str = "left_right",
+) -> np.ndarray:
+    """
+    Load a mirrored In115 concentration dataset created by
+    create_mirrored_concentration_data.
+
+    Args:
+        data_dir: Directory containing the mirrored .npy file.
+        region_bounds (list): [left, right, top, bottom] used at creation time.
+        mirror_type (str): "left_right" or "right_left".
+
+    Returns:
+        ndarray: Mirrored concentration fraction at each site.
+    """
+    data_dir = pathlib.Path(data_dir)
+    region_bounds = list(region_bounds)
+    return np.load(
+        data_dir / f"{mirror_type}_mirrored_In_conc_data_in_region_{region_bounds}.npy"
+    )
+
+
+def _nmr_map_path(
+    data_dir: pathlib.Path | str,
+    nuclear_species: str,
+    field_geometry: str,
+    n_locations: int,
+    region_bounds: list[int],
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+) -> pathlib.Path:
+    """Build the canonical archive filename for a 2D NMR absorption map."""
+    data_dir = pathlib.Path(data_dir)
+    region_bounds = list(region_bounds)
+    base = (
+        f"nmr_map_{nuclear_species}_{field_geometry}_{n_locations}locs"
+        f"_region{region_bounds}"
+        f"_{len(applied_field_list)}fields_{applied_field_list[0]:g}-{applied_field_list[-1]:g}T"
+        f"_{len(rf_freq_list)}freqs_{rf_freq_list[0] / 1e6:g}-{rf_freq_list[-1] / 1e6:g}MHz"
+    )
+    if not real_strain:
+        base += f"_using_{mirror_type}_flipped_data"
+    if use_sundfors:
+        base += "_with_old_params"
+    return data_dir / f"{base}.npz"
+
+
+def save_nmr_map(
+    data_dir: pathlib.Path | str,
+    nuclear_species: str,
+    field_geometry: str,
+    region_bounds: list[int],
+    absorption_data: np.ndarray,
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    locations: list[tuple[int, int]],
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+    overwrite: bool = False,
+) -> None:
+    """
+    Save a pre-computed 2D NMR absorption map to a .npz archive.
+
+    If the archive already exists it is left untouched (a warning is logged).
+    Pass overwrite=True to replace it.
+
+    Args:
+        data_dir: Directory to write the archive into.
+        nuclear_species (str): One of "Ga69", "Ga71", "As75", "In115".
+        field_geometry (str): "Faraday" or "Voigt".
+        region_bounds (list): [left, right, top, bottom].
+        absorption_data (ndarray): Map from qdot.nmr.absorption_map,
+            shape (n_fields, n_freqs).
+        applied_field_list (ndarray): Applied fields in Tesla.
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        locations (list of (int, int)): Lattice sites the map was summed over.
+        use_sundfors (bool): True if the Sundfors parameter set was used.
+        real_strain (bool): False if mirrored strain data was used.
+        mirror_type (str): Mirror variant, only used when real_strain=False.
+        overwrite (bool): Replace an existing archive instead of skipping it.
+    """
+    path = _nmr_map_path(
+        data_dir,
+        nuclear_species,
+        field_geometry,
+        len(locations),
+        region_bounds,
+        applied_field_list,
+        rf_freq_list,
+        use_sundfors,
+        real_strain,
+        mirror_type,
+    )
+    if path.exists() and not overwrite:
+        logger.warning("NMR map archive already exists, not overwriting: %s", path)
+        return
+    np.savez(
+        path,
+        absorption_data=absorption_data,
+        applied_field_list=np.asarray(applied_field_list),
+        rf_freq_list=np.asarray(rf_freq_list),
+        locations=np.asarray(locations),
+    )
+    logger.info("Saved NMR map archive: %s", path)
+
+
+def load_nmr_map(
+    data_dir: pathlib.Path | str,
+    nuclear_species: str,
+    field_geometry: str,
+    n_locations: int,
+    region_bounds: list[int],
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Load a pre-computed 2D NMR absorption map saved by save_nmr_map.
+
+    The filename is reconstructed from the parameters, so they must match the
+    values used when the map was saved.
+
+    Returns:
+        absorption_data (ndarray): Shape (n_fields, n_freqs).
+        applied_field_list (ndarray): Applied fields in Tesla.
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        locations (ndarray): Lattice sites, shape (n_locations, 2).
+    """
+    path = _nmr_map_path(
+        data_dir,
+        nuclear_species,
+        field_geometry,
+        n_locations,
+        region_bounds,
+        applied_field_list,
+        rf_freq_list,
+        use_sundfors,
+        real_strain,
+        mirror_type,
+    )
+    archive = np.load(path)
+    return (
+        archive["absorption_data"],
+        archive["applied_field_list"],
+        archive["rf_freq_list"],
+        archive["locations"],
     )

--- a/qdot/isotopes.py
+++ b/qdot/isotopes.py
@@ -18,6 +18,8 @@ Two parameter sets are provided:
 
 from typing import TypedDict
 
+import scipy.constants as const
+
 
 class SpeciesParameters(TypedDict):
     short_name: str
@@ -117,6 +119,25 @@ As_75_Old = {
     "S11": 3.96e22,
     "S44": 7.94e22,
 }
+
+
+def quadrupole_coupling(species: SpeciesParameters) -> float:
+    """
+    Quadrupole coupling constant K = 3eQ / (2hI(2I-1)).
+
+    Multiplying K by the principal EFG component V_ZZ gives the quadrupolar
+    frequency in Hz.
+
+    Args:
+        species (SpeciesParameters): One entry of species_dict / old_species_dict.
+
+    Returns:
+        float: Coupling constant in Hz per V·m⁻².
+    """
+    spin = species["particle_spin"]
+    Q = species["quadrupole_moment"]
+    return (3 * const.e * Q) / (2 * const.h * spin * (2 * spin - 1))
+
 
 species_dict: dict[str, SpeciesParameters] = {
     "Ga69": Ga_69,

--- a/qdot/machine_gun.py
+++ b/qdot/machine_gun.py
@@ -195,3 +195,225 @@ def machine_gun_with_pauli_errors(
         total = dot_rotator @ cnot @ error_mat @ total
 
     return total
+
+
+# ---------------------------------------------------------------------------
+# Density-matrix formulation with error channels
+# ---------------------------------------------------------------------------
+
+
+def initial_density_matrix(n_photons: int) -> qutip.Qobj:
+    """
+    Density matrix |0...0⟩⟨0...0| for the dot + n_photons system.
+
+    Args:
+        n_photons (int): Number of photon qubits.
+
+    Returns:
+        Qobj: Density matrix of dimension 2^(n_photons + 1).
+    """
+    return qutip.Qobj(state_to_density_matrix(state_constructor(n_photons)))
+
+
+def _embedded_kraus_superoperator(
+    K_0: np.ndarray, K_1: np.ndarray, n_photons: int
+) -> qutip.Qobj:
+    """Embed a 2x2 Kraus pair on the dot qubit and build the superoperator."""
+    full_K_0 = qutip.Qobj(single_qubit_operation(K_0, n_photons + 1, 1))
+    full_K_1 = qutip.Qobj(single_qubit_operation(K_1, n_photons + 1, 1))
+    return qutip.superop_reps.kraus_to_super([full_K_0, full_K_1])
+
+
+def dot_dephasing_superoperator(n_photons: int, dephasing: float) -> qutip.Qobj:
+    """
+    Phase-damping channel on the dot qubit as a full-system superoperator.
+
+    Kraus operators K_0 = diag(1, √(1−p)), K_1 = diag(0, √p) acting on the
+    dot, embedded into the (n_photons + 1)-qubit space. p = 0 is the identity
+    channel; p = 1 fully removes the dot's coherences.
+
+    Args:
+        n_photons (int): Number of photon qubits.
+        dephasing (float): Dephasing strength p in [0, 1].
+
+    Returns:
+        Qobj: Superoperator on the full system.
+    """
+    K_0 = np.array([[1, 0], [0, np.sqrt(1 - dephasing)]])
+    K_1 = np.array([[0, 0], [0, np.sqrt(dephasing)]])
+    return _embedded_kraus_superoperator(K_0, K_1, n_photons)
+
+
+def dot_damping_superoperator(n_photons: int, damping: float) -> qutip.Qobj:
+    """
+    Amplitude-damping channel on the dot qubit as a full-system superoperator.
+
+    Kraus operators K_0 = diag(1, √(1−p)), K_1 = [[0, √p], [0, 0]] acting on
+    the dot, embedded into the (n_photons + 1)-qubit space. p = 0 is the
+    identity channel; p = 1 fully relaxes the dot to |0⟩.
+
+    Args:
+        n_photons (int): Number of photon qubits.
+        damping (float): Damping strength p in [0, 1].
+
+    Returns:
+        Qobj: Superoperator on the full system.
+    """
+    K_0 = np.array([[1, 0], [0, np.sqrt(1 - damping)]])
+    K_1 = np.array([[0, np.sqrt(damping)], [0, 0]])
+    return _embedded_kraus_superoperator(K_0, K_1, n_photons)
+
+
+def _run_density_matrix_protocol(
+    n_photons: int, error_superop: qutip.Qobj | None = None
+) -> qutip.Qobj:
+    """
+    Run the CSMG protocol on a vectorised density matrix.
+
+    Applies the same sequence as perfect_cluster_state_machine_gun
+    (Uy, then per photon: error channel, CNOT, Uy) plus a final error-channel
+    application, so noise also acts during the last cycle's wait. The original
+    research code applied the trailing channel only in the dephasing variant;
+    here it is applied uniformly for both channels.
+    """
+    rho_vec = qutip.superoperator.operator_to_vector(initial_density_matrix(n_photons))
+
+    Pauli_Y = np.array([[0, -1j], [1j, 0]])
+    R_y = expm(-1j * np.pi / 4 * Pauli_Y)
+    U_y = qutip.Qobj(single_qubit_operation(R_y, n_photons + 1, 1))
+    U_y_super = qutip.superop_reps.to_super(U_y)
+
+    rho_vec = U_y_super * rho_vec
+    for i in range(n_photons):
+        cnot_super = qutip.superop_reps.to_super(
+            qutip.Qobj(controlled_unitary(n_photons, i + 1))
+        )
+        if error_superop is not None:
+            rho_vec = error_superop * rho_vec
+        rho_vec = U_y_super * cnot_super * rho_vec
+
+    if error_superop is not None:
+        rho_vec = error_superop * rho_vec
+
+    return qutip.superoperator.vector_to_operator(rho_vec)
+
+
+def perfect_machine_gun_density_matrix(n_photons: int) -> qutip.Qobj:
+    """
+    Final density matrix of the ideal (error-free) machine gun protocol.
+
+    Equivalent to the state-vector path: equals
+    |ψ⟩⟨ψ| with ψ = operational_perfect_machine_gun(n_photons).
+
+    Args:
+        n_photons (int): Number of photon qubits.
+
+    Returns:
+        Qobj: Final density matrix.
+    """
+    return _run_density_matrix_protocol(n_photons, None)
+
+
+def noisy_machine_gun(
+    n_photons: int, error_channel: str, error_strength: float
+) -> qutip.Qobj:
+    """
+    Machine gun protocol with an error channel applied to the dot each cycle.
+
+    Args:
+        n_photons (int): Number of photon qubits.
+        error_channel (str): "dephasing" (phase damping) or "damping"
+            (amplitude damping).
+        error_strength (float): Channel strength in [0, 1]; 0 reproduces the
+            perfect protocol.
+
+    Returns:
+        Qobj: Final density matrix.
+    """
+    if error_channel == "dephasing":
+        error_superop = dot_dephasing_superoperator(n_photons, error_strength)
+    elif error_channel == "damping":
+        error_superop = dot_damping_superoperator(n_photons, error_strength)
+    else:
+        raise ValueError(
+            f"error_channel must be 'dephasing' or 'damping', got {error_channel!r}"
+        )
+    return _run_density_matrix_protocol(n_photons, error_superop)
+
+
+def fidelity_vs_error(
+    n_photons: int,
+    error_strengths: np.ndarray,
+    error_channel: str = "dephasing",
+) -> np.ndarray:
+    """
+    Fidelity of the noisy machine gun output against the perfect output.
+
+    Args:
+        n_photons (int): Number of photon qubits.
+        error_strengths (ndarray): Channel strengths to sweep, each in [0, 1].
+        error_channel (str): "dephasing" or "damping".
+
+    Returns:
+        ndarray: Fidelity at each error strength, shape (len(error_strengths),).
+    """
+    perfect = perfect_machine_gun_density_matrix(n_photons)
+    return np.array(
+        [
+            qutip.fidelity(perfect, noisy_machine_gun(n_photons, error_channel, s))
+            for s in error_strengths
+        ]
+    )
+
+
+def trace_distance_vs_error(
+    n_photons: int,
+    error_strengths: np.ndarray,
+    error_channel: str = "dephasing",
+) -> np.ndarray:
+    """
+    Trace distance of the noisy machine gun output from the perfect output.
+
+    Args:
+        n_photons (int): Number of photon qubits.
+        error_strengths (ndarray): Channel strengths to sweep, each in [0, 1].
+        error_channel (str): "dephasing" or "damping".
+
+    Returns:
+        ndarray: Trace distance at each error strength.
+    """
+    perfect = perfect_machine_gun_density_matrix(n_photons)
+    return np.array(
+        [
+            qutip.tracedist(perfect, noisy_machine_gun(n_photons, error_channel, s))
+            for s in error_strengths
+        ]
+    )
+
+
+def error_list_to_array(
+    error_list: list[tuple[int, str]], n_photons: int
+) -> np.ndarray:
+    """
+    Convert a readable error list into the array machine_gun_with_pauli_errors takes.
+
+    Args:
+        error_list (list): Entries (photon_index, "X"|"Y"|"Z") with photon
+            indices counted from 1, e.g. [(1, "Z"), (3, "X")].
+        n_photons (int): Number of photon qubits.
+
+    Returns:
+        ndarray: Shape (n_photons, 2). Column 0: 1 if an error occurs on that
+        photon's cycle, 0 otherwise. Column 1: error code 2=X, 3=Y, 4=Z.
+    """
+    codes = {"X": 2, "Y": 3, "Z": 4}
+    errors_array = np.zeros((n_photons, 2), dtype=int)
+    for photon_index, label in error_list:
+        if not 1 <= photon_index <= n_photons:
+            raise ValueError(
+                f"photon_index must be in [1, {n_photons}], got {photon_index}"
+            )
+        if label not in codes:
+            raise ValueError(f"error label must be 'X', 'Y' or 'Z', got {label!r}")
+        errors_array[photon_index - 1] = (1, codes[label])
+    return errors_array

--- a/qdot/nff.py
+++ b/qdot/nff.py
@@ -96,3 +96,40 @@ def non_dephased_polarisation(q0: float, phase: float) -> float:
     pulse_op = pulse_kraus_operator(q0, phase)
     final_dm = qutip.superoperator.vector_to_operator(pulse_op * initial_vec)
     return float(np.real_if_close(z_polarisation(final_dm)))
+
+
+def x_polarisation(density_matrix: qutip.Qobj) -> complex:
+    """
+    Expectation of the Pauli x operator, Tr(σx·ρ).
+
+    Note: unlike z_polarisation, no basis rotation is applied — this is the
+    plain σx expectation of the density matrix as given (the convention of
+    the original research code; see human-todo.).
+    """
+    return (qutip.sigmax() * density_matrix).tr()
+
+
+def y_polarisation(density_matrix: qutip.Qobj) -> complex:
+    """
+    Expectation of the Pauli y operator, Tr(σy·ρ).
+
+    See the basis-convention note on x_polarisation.
+    """
+    return (qutip.sigmay() * density_matrix).tr()
+
+
+def dephasing_from_scattering(scattering_probability: float) -> float:
+    """
+    Phase damping parameter produced by photon scattering.
+
+    γ = (1 + √(1 − p)) / 2, mapping a photon scattering probability p in
+    [0, 1] onto the dephasing parameter range [0.5, 1] used by
+    dephasing_kraus_operator (1 = no dephasing, 0.5 = maximal).
+
+    Args:
+        scattering_probability (float): Photon scattering probability in [0, 1].
+
+    Returns:
+        float: Dephasing parameter γ in [0.5, 1].
+    """
+    return (1 + np.sqrt(1 - scattering_probability)) / 2

--- a/qdot/nmr.py
+++ b/qdot/nmr.py
@@ -4,16 +4,25 @@ NMR absorption spectra for nuclear spins in InGaAs quantum dots.
 Computes transition rates between eigenstates of the nuclear Hamiltonian
 under an RF perturbation, building up an absorption spectrum by summing
 over all allowed transitions at each RF frequency.
+
+Beyond the single-site spectrum, this module provides the multi-site
+parallel engine (absorption_map / summed_absorption_spectrum), the
+concentration-weighted experimental simulation, the combined all-species
+spectrum, and the RF pulse selectivity analysis from the original research
+scripts.
 """
 
+import math
+import multiprocessing
 import pathlib
 from itertools import permutations
 
 import numpy as np
-import scipy.constants as const
+from scipy.integrate import simpson
 
-from qdot.isotopes import species_dict
-from qdot.io import load_efg, SOKOLOV_DOT_REGION
+from qdot.isotopes import species_dict, quadrupole_coupling
+from qdot.io import load_efg, load_concentration_data, SOKOLOV_DOT_REGION
+from qdot.sites import random_locations
 from qdot.hamiltonians import (
     faraday_hamiltonian,
     voigt_hamiltonian,
@@ -23,8 +32,95 @@ from qdot.hamiltonians import (
 
 _VALID_SPECIES = frozenset(species_dict)
 
-h = const.h
-e = const.e
+
+def _single_site_spectrum(
+    spin: float,
+    zeeman_term: float,
+    quadrupolar_term: float,
+    biaxiality: float,
+    alpha: float,
+    beta: float,
+    gamma: float,
+    field_geometry: str,
+    rf_freqs: np.ndarray,
+    rf_field: float,
+) -> np.ndarray:
+    """
+    Absorption spectrum of a single nucleus from explicit Hamiltonian terms.
+
+    Module-level so multiprocessing can pickle it for the parallel engine.
+    """
+    if field_geometry == "Faraday":
+        H = faraday_hamiltonian(
+            zeeman_term, quadrupolar_term, biaxiality, spin, alpha, beta, gamma
+        )
+        H_rf = rf_hamiltonian(spin, rf_field, 0, 0)
+    elif field_geometry == "Voigt":
+        H = voigt_hamiltonian(
+            zeeman_term, quadrupolar_term, biaxiality, spin, alpha, beta, gamma
+        )
+        H_rf = rf_hamiltonian(spin, 0, 0, rf_field)
+    else:
+        raise ValueError(
+            f"field_geometry must be 'Faraday' or 'Voigt', got {field_geometry!r}"
+        )
+
+    H = H.tidyup()
+    eigenvalues, eigenvectors = H.eigenstates()
+    eigenenergies = np.real_if_close(eigenvalues)
+    index_list = np.arange(len(eigenenergies))
+
+    # Each pair's matrix element is independent of the RF frequency, so compute
+    # it once per pair and let transition_rate broadcast over the whole
+    # frequency array.
+    rates = np.zeros(len(rf_freqs))
+    for pair in permutations(index_list, 2):
+        rates += transition_rate(
+            H_rf,
+            eigenvectors[pair[0]],
+            eigenvectors[pair[1]],
+            eigenenergies[pair[0]],
+            eigenenergies[pair[1]],
+            rf_freqs,
+        )
+    return rates
+
+
+def _site_parameters(
+    data_dir: pathlib.Path | str,
+    nuclear_species: str,
+    region_bounds: list[int],
+    locations: list[tuple[int, int]],
+    step_size: int,
+    use_sundfors: bool,
+    real_strain: bool,
+    mirror_type: str,
+) -> tuple[float, float, list[tuple[float, float, float, float, float]]]:
+    """
+    Load the EFG archive once and extract per-site Hamiltonian parameters.
+
+    Returns:
+        spin, zeeman_per_tesla, and a list of
+        (biaxiality, quadrupolar_term, alpha, beta, gamma) per location.
+    """
+    eta_arr, _, _, V_ZZ_arr, euler_arr = load_efg(
+        data_dir,
+        nuclear_species,
+        region_bounds,
+        step_size=step_size,
+        use_sundfors=use_sundfors,
+        real_strain=real_strain,
+        mirror_type=mirror_type,
+    )
+    species = species_dict[nuclear_species]
+    qcc = quadrupole_coupling(species)
+    n_cols = V_ZZ_arr.shape[1]
+
+    site_params = []
+    for x, y in locations:
+        alpha, beta, gamma = euler_arr[x * n_cols + y]
+        site_params.append((eta_arr[x, y], qcc * V_ZZ_arr[x, y], alpha, beta, gamma))
+    return species["particle_spin"], species["zeeman_frequency_per_tesla"], site_params
 
 
 def absorption_spectrum(
@@ -38,6 +134,8 @@ def absorption_spectrum(
     step_size: int = 1,
     rf_field: float = 5e-3,
     use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
 ) -> np.ndarray:
     """
     NMR absorption spectrum at a single lattice site.
@@ -56,6 +154,8 @@ def absorption_spectrum(
         step_size (int): Subsample interval the EFG archive was saved with.
         rf_field (float): RF field amplitude. Default 5 mT.
         use_sundfors (bool): Use Sundfors parameter set if True.
+        real_strain (bool): False to use a mirrored-strain EFG archive.
+        mirror_type (str): Mirror variant, only used when real_strain=False.
 
     Returns:
         ndarray: Transition rate at each RF frequency, shape (len(rf_freq_list),).
@@ -67,61 +167,29 @@ def absorption_spectrum(
     if region_bounds is None:
         region_bounds = SOKOLOV_DOT_REGION
 
-    x, y = location
-    eta_arr, _, _, V_ZZ_arr, euler_arr = load_efg(
+    spin, zeeman_per_tesla, site_params = _site_parameters(
         data_dir,
         nuclear_species,
         region_bounds,
-        step_size=step_size,
-        use_sundfors=use_sundfors,
+        [location],
+        step_size,
+        use_sundfors,
+        real_strain,
+        mirror_type,
     )
-
-    species = species_dict[nuclear_species]
-    spin = species["particle_spin"]
-    zeeman_per_tesla = species["zeeman_frequency_per_tesla"]
-    Q = species["quadrupole_moment"]
-    qcc = (3 * e * Q) / (2 * h * spin * (2 * spin - 1))
-
-    eta = eta_arr[x, y]
-    V_ZZ = V_ZZ_arr[x, y]
-    site_idx = x * V_ZZ_arr.shape[1] + y
-    alpha, beta, gamma = euler_arr[site_idx]
-
-    zeeman_term = zeeman_per_tesla * applied_field
-    quad_term = qcc * V_ZZ
-
-    if field_geometry == "Faraday":
-        H = faraday_hamiltonian(zeeman_term, quad_term, eta, spin, alpha, beta, gamma)
-        H_rf = rf_hamiltonian(spin, rf_field, 0, 0)
-    elif field_geometry == "Voigt":
-        H = voigt_hamiltonian(zeeman_term, quad_term, eta, spin, alpha, beta, gamma)
-        H_rf = rf_hamiltonian(spin, 0, 0, rf_field)
-    else:
-        raise ValueError(
-            f"field_geometry must be 'Faraday' or 'Voigt', got {field_geometry!r}"
-        )
-
-    H = H.tidyup()
-    eigenvalues, eigenvectors = H.eigenstates()
-    eigenenergies = np.real_if_close(eigenvalues)
-    index_list = np.arange(len(eigenenergies))
-
-    # Each pair's matrix element is independent of the RF frequency, so compute
-    # it once per pair and let transition_rate broadcast over the whole
-    # frequency array.
-    rf_freqs = np.asarray(rf_freq_list)
-    rates = np.zeros(len(rf_freqs))
-    for pair in permutations(index_list, 2):
-        rates += transition_rate(
-            H_rf,
-            eigenvectors[pair[0]],
-            eigenvectors[pair[1]],
-            eigenenergies[pair[0]],
-            eigenenergies[pair[1]],
-            rf_freqs,
-        )
-
-    return rates
+    eta, quad_term, alpha, beta, gamma = site_params[0]
+    return _single_site_spectrum(
+        spin,
+        zeeman_per_tesla * applied_field,
+        quad_term,
+        eta,
+        alpha,
+        beta,
+        gamma,
+        field_geometry,
+        np.asarray(rf_freq_list),
+        rf_field,
+    )
 
 
 def varied_field_spectra(
@@ -135,6 +203,8 @@ def varied_field_spectra(
     step_size: int = 1,
     rf_field: float = 5e-3,
     use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
 ) -> list[dict]:
     """
     Compute absorption spectra at multiple applied field strengths.
@@ -150,6 +220,8 @@ def varied_field_spectra(
         step_size (int): Subsample interval the EFG archive was saved with.
         rf_field (float): RF field amplitude. Default 5 mT.
         use_sundfors (bool): Use Sundfors parameter set if True.
+        real_strain (bool): False to use a mirrored-strain EFG archive.
+        mirror_type (str): Mirror variant, only used when real_strain=False.
 
     Returns:
         list of dict: Each entry has keys "applied_field", "rf_freq_list", "data".
@@ -169,7 +241,333 @@ def varied_field_spectra(
                 step_size=step_size,
                 rf_field=rf_field,
                 use_sundfors=use_sundfors,
+                real_strain=real_strain,
+                mirror_type=mirror_type,
             ),
         }
         for B in applied_field_list
     ]
+
+
+def absorption_map(
+    nuclear_species: str,
+    applied_field_list: np.ndarray,
+    field_geometry: str,
+    rf_freq_list: np.ndarray,
+    locations: list[tuple[int, int]],
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int] | None = None,
+    step_size: int = 1,
+    rf_field: float = 5e-3,
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+    processes: int | None = None,
+) -> np.ndarray:
+    """
+    2D NMR absorption map over applied field and RF frequency.
+
+    For each applied field, computes the single-site spectrum at every
+    location in parallel (multiprocessing.Pool) and sums over sites. This is
+    the multi-site engine behind the field-frequency heatmaps; the EFG
+    archive is loaded once for the whole map.
+
+    Args:
+        nuclear_species (str): One of "Ga69", "Ga71", "As75", "In115".
+        applied_field_list (ndarray): Applied fields to sweep, in Tesla.
+        field_geometry (str): "Faraday" or "Voigt".
+        rf_freq_list (ndarray): RF frequencies to evaluate (Hz).
+        locations (list of (int, int)): Lattice sites to sum over.
+        data_dir: Directory containing pre-computed EFG archives.
+        region_bounds (list): [left, right, top, bottom]. Defaults to dot region.
+        step_size (int): Subsample interval the EFG archive was saved with.
+        rf_field (float): RF field amplitude. Default 5 mT.
+        use_sundfors (bool): Use Sundfors parameter set if True.
+        real_strain (bool): False to use a mirrored-strain EFG archive.
+        mirror_type (str): Mirror variant, only used when real_strain=False.
+        processes (int): Worker process count. Default: all available cores.
+
+    Returns:
+        ndarray: Summed absorption, shape (len(applied_field_list), len(rf_freq_list)).
+    """
+    if nuclear_species not in _VALID_SPECIES:
+        raise ValueError(
+            f"nuclear_species must be one of {sorted(_VALID_SPECIES)}, got {nuclear_species!r}"
+        )
+    if region_bounds is None:
+        region_bounds = SOKOLOV_DOT_REGION
+
+    rf_freqs = np.asarray(rf_freq_list)
+    data = np.zeros((len(applied_field_list), len(rf_freqs)))
+    if not locations:
+        return data
+
+    spin, zeeman_per_tesla, site_params = _site_parameters(
+        data_dir,
+        nuclear_species,
+        region_bounds,
+        locations,
+        step_size,
+        use_sundfors,
+        real_strain,
+        mirror_type,
+    )
+
+    with multiprocessing.Pool(processes) as pool:
+        for b, applied_field in enumerate(applied_field_list):
+            zeeman_term = zeeman_per_tesla * applied_field
+            args = [
+                (
+                    spin,
+                    zeeman_term,
+                    quad_term,
+                    eta,
+                    alpha,
+                    beta,
+                    gamma,
+                    field_geometry,
+                    rf_freqs,
+                    rf_field,
+                )
+                for eta, quad_term, alpha, beta, gamma in site_params
+            ]
+            site_spectra = pool.starmap(_single_site_spectrum, args)
+            data[b] = np.sum(site_spectra, axis=0)
+
+    return data
+
+
+def summed_absorption_spectrum(
+    nuclear_species: str,
+    applied_field: float,
+    field_geometry: str,
+    rf_freq_list: np.ndarray,
+    locations: list[tuple[int, int]],
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int] | None = None,
+    step_size: int = 1,
+    rf_field: float = 5e-3,
+    use_sundfors: bool = False,
+    real_strain: bool = True,
+    mirror_type: str = "left_right",
+    processes: int | None = None,
+) -> np.ndarray:
+    """
+    Absorption spectrum at one applied field, summed over many lattice sites.
+
+    A single row of absorption_map; see there for argument details.
+
+    Returns:
+        ndarray: Summed absorption at each RF frequency, shape (len(rf_freq_list),).
+    """
+    return absorption_map(
+        nuclear_species,
+        np.array([applied_field]),
+        field_geometry,
+        rf_freq_list,
+        locations,
+        data_dir,
+        region_bounds,
+        step_size=step_size,
+        rf_field=rf_field,
+        use_sundfors=use_sundfors,
+        real_strain=real_strain,
+        mirror_type=mirror_type,
+        processes=processes,
+    )[0]
+
+
+def experimental_nmr_simulation(
+    field_geometry: str,
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    n_locations: int,
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int] | None = None,
+    step_size: int = 1,
+    rf_field: float = 5e-3,
+    arsenic_fraction: float = 0.5,
+    rng: np.random.Generator | int | None = None,
+    processes: int | None = None,
+) -> dict[str, np.ndarray]:
+    """
+    Concentration-weighted multi-species NMR simulation of the dot.
+
+    Splits n_locations lattice sites into species populations from the In
+    concentration map — In115 sites in proportion to the mean In
+    concentration, an arsenic_fraction share of As75, the remainder Ga69 —
+    samples random sites for each species, and computes each species'
+    absorption map. Following the original research code, Ga71 is excluded;
+    the population heuristic is recorded in human-todo. for physics review.
+
+    Returns the per-species maps so the caller can choose between a summed
+    rendering (plot_nmr_map of the total) and a layered one
+    (plot_nmr_map_layered).
+
+    Args:
+        field_geometry (str): "Faraday" or "Voigt".
+        applied_field_list (ndarray): Applied fields in Tesla.
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        n_locations (int): Total number of nuclei to simulate.
+        data_dir: Directory containing EFG archives and concentration data.
+        region_bounds (list): [left, right, top, bottom]. Defaults to dot region.
+        step_size (int): Subsample interval of the archives.
+        rf_field (float): RF field amplitude. Default 5 mT.
+        arsenic_fraction (float): Fraction of sites assigned to As75. Default 0.5.
+        rng: numpy Generator, integer seed, or None for fresh entropy.
+        processes (int): Worker process count. Default: all available cores.
+
+    Returns:
+        dict: Species name → absorption map, shape (n_fields, n_freqs), for
+        "In115", "Ga69" and "As75".
+    """
+    if region_bounds is None:
+        region_bounds = SOKOLOV_DOT_REGION
+
+    conc_data = load_concentration_data(data_dir, region_bounds, step_size)
+    mean_in_conc = float(np.mean(conc_data))
+
+    n_in = int(math.ceil(mean_in_conc * n_locations))
+    n_as = int(math.ceil(arsenic_fraction * n_locations))
+    n_ga = n_locations - n_in - n_as
+    if n_ga < 0:
+        raise ValueError(
+            f"n_locations={n_locations} is too small for the population split "
+            f"(In: {n_in}, As: {n_as})"
+        )
+
+    rng = np.random.default_rng(rng)
+    maps = {}
+    for nuclear_species, n_sites in (("In115", n_in), ("Ga69", n_ga), ("As75", n_as)):
+        locations = random_locations(n_sites, conc_data.shape, rng)
+        maps[nuclear_species] = absorption_map(
+            nuclear_species,
+            applied_field_list,
+            field_geometry,
+            rf_freq_list,
+            locations,
+            data_dir,
+            region_bounds,
+            step_size=step_size,
+            rf_field=rf_field,
+            processes=processes,
+        )
+    return maps
+
+
+def combined_spectrum(
+    applied_field: float,
+    field_geometry: str,
+    rf_freq_list: np.ndarray,
+    locations: list[tuple[int, int]],
+    data_dir: pathlib.Path | str,
+    region_bounds: list[int] | None = None,
+    step_size: int = 1,
+    rf_field: float = 5e-3,
+    use_sundfors: bool = False,
+    processes: int | None = None,
+) -> np.ndarray:
+    """
+    All-species absorption spectrum at one applied field, normalised to 1.
+
+    Sums the spectra of all four species over the same site list — the input
+    to peak identification and RF pulse selectivity analysis.
+
+    Args:
+        applied_field (float): Static magnetic field in Tesla.
+        field_geometry (str): "Faraday" or "Voigt".
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        locations (list of (int, int)): Lattice sites shared by all species.
+        data_dir: Directory containing pre-computed EFG archives.
+        region_bounds (list): [left, right, top, bottom]. Defaults to dot region.
+        step_size (int): Subsample interval of the archives.
+        rf_field (float): RF field amplitude. Default 5 mT.
+        use_sundfors (bool): Use Sundfors parameter set if True.
+        processes (int): Worker process count. Default: all available cores.
+
+    Returns:
+        ndarray: Normalised total absorption, shape (len(rf_freq_list),).
+    """
+    total = np.zeros(len(rf_freq_list))
+    for nuclear_species in sorted(_VALID_SPECIES):
+        total += summed_absorption_spectrum(
+            nuclear_species,
+            applied_field,
+            field_geometry,
+            rf_freq_list,
+            locations,
+            data_dir,
+            region_bounds,
+            step_size=step_size,
+            rf_field=rf_field,
+            use_sundfors=use_sundfors,
+            processes=processes,
+        )
+    return total / np.amax(total)
+
+
+def lorentzian_pulse(
+    rf_freq_list: np.ndarray, centre: float, width: float
+) -> np.ndarray:
+    """
+    Lorentzian (Cauchy) frequency profile of an RF pulse.
+
+    Args:
+        rf_freq_list (ndarray): Frequencies at which to evaluate the profile.
+        centre (float): Pulse centre frequency, same units as rf_freq_list.
+        width (float): Full width of the pulse; the Lorentzian half-width is
+            width / 2.
+
+    Returns:
+        ndarray: Pulse profile (unit-area Cauchy distribution).
+    """
+    gamma = width / 2
+    freqs = np.asarray(rf_freq_list)
+    return 1 / (np.pi * gamma * (1 + ((freqs - centre) / gamma) ** 2))
+
+
+def pulse_capture_fraction(
+    spectrum: np.ndarray,
+    rf_freq_list: np.ndarray,
+    pulse_centre: float,
+    pulse_width: float,
+    window: tuple[float, float] | None = None,
+) -> float:
+    """
+    Fraction of spectral weight a Lorentzian pulse captures.
+
+    Multiplies the spectrum by the pulse profile (normalised to unit peak)
+    and Simpson-integrates. With window=None the fraction is over the whole
+    spectrum; with a (min_freq, max_freq) window both integrals are restricted
+    to that band, giving the in-band capture fraction used to assess whether a
+    pulse can address one species without touching others.
+
+    Args:
+        spectrum (ndarray): Absorption spectrum, e.g. from combined_spectrum.
+        rf_freq_list (ndarray): Frequencies of the spectrum samples.
+        pulse_centre (float): Pulse centre, same units as rf_freq_list.
+        pulse_width (float): Pulse full width, same units as rf_freq_list.
+        window (tuple): Optional (min_freq, max_freq) integration band.
+
+    Returns:
+        float: Captured fraction in [0, 1].
+    """
+    freqs = np.asarray(rf_freq_list)
+    spectrum = np.asarray(spectrum)
+
+    pulse = lorentzian_pulse(freqs, pulse_centre, pulse_width)
+    pulse = pulse / np.amax(pulse)
+    filtered = spectrum * pulse
+
+    if window is not None:
+        low, high = window
+        low_idx = int(np.abs(freqs - low).argmin())
+        high_idx = int(np.abs(freqs - high).argmin())
+        selection = slice(low_idx, high_idx + 1)
+    else:
+        selection = slice(None)
+
+    return float(
+        simpson(filtered[selection], x=freqs[selection])
+        / simpson(spectrum[selection], x=freqs[selection])
+    )

--- a/qdot/plot.py
+++ b/qdot/plot.py
@@ -16,6 +16,9 @@ from matplotlib.colors import Normalize
 from matplotlib.lines import Line2D
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
+from scipy.optimize import curve_fit
+from scipy.stats import maxwell, gamma as gamma_dist
+
 from qdot.isotopes import species_dict
 
 # ---------------------------------------------------------------------------
@@ -375,3 +378,796 @@ def _save_or_show(fig: plt.Figure, save_path: pathlib.Path | str | None) -> None
     else:
         plt.show()
     plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# NMR field-frequency maps
+# ---------------------------------------------------------------------------
+
+
+def _nmr_extent(applied_field_list, rf_freq_list) -> list[float]:
+    """Image extent [f_min(MHz), f_max(MHz), B_min(T), B_max(T)] for NMR maps."""
+    return [
+        rf_freq_list[0] / 1e6,
+        rf_freq_list[-1] / 1e6,
+        applied_field_list[0],
+        applied_field_list[-1],
+    ]
+
+
+def plot_nmr_map(
+    absorption_data: np.ndarray,
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    log_scale: bool = True,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Heatmap of a 2D NMR absorption map (applied field × RF frequency).
+
+    Args:
+        absorption_data (ndarray): Map from qdot.nmr.absorption_map,
+            shape (n_fields, n_freqs).
+        applied_field_list (ndarray): Applied fields in Tesla.
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        log_scale (bool): Plot log(absorption). Default True.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    data = np.log(absorption_data) if log_scale else absorption_data
+
+    fig, ax = plt.subplots()
+    ax.imshow(
+        data,
+        origin="lower",
+        cmap=cm.GnBu,
+        aspect="auto",
+        extent=_nmr_extent(applied_field_list, rf_freq_list),
+        interpolation="none",
+    )
+    ax.set_xlabel("RF Frequency (MHz)")
+    ax.set_ylabel("Applied B Field (T)")
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_nmr_map_pair(
+    absorption_data_a: np.ndarray,
+    absorption_data_b: np.ndarray,
+    labels: tuple[str, str],
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    log_scale: bool = True,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Side-by-side comparison of two NMR maps (e.g. Faraday vs Voigt, or
+    Checkhovich vs Sundfors parameter sets).
+
+    Args:
+        absorption_data_a, absorption_data_b (ndarray): Maps, shape (n_fields, n_freqs).
+        labels (tuple): Panel titles, e.g. ("Faraday", "Voigt").
+        applied_field_list (ndarray): Applied fields in Tesla.
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        log_scale (bool): Plot log(absorption). Default True.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    extent = _nmr_extent(applied_field_list, rf_freq_list)
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
+
+    for ax, data, label, letter in zip(
+        axes, (absorption_data_a, absorption_data_b), labels, "ab"
+    ):
+        plot_data = np.log(data) if log_scale else data
+        ax.imshow(
+            plot_data,
+            origin="lower",
+            cmap=cm.GnBu,
+            aspect="auto",
+            extent=extent,
+            interpolation="none",
+        )
+        ax.set_xlabel("RF Frequency (MHz)")
+        ax.set_title(label)
+        ax.text(0.02, 0.95, letter, transform=ax.transAxes, fontsize=14)
+
+    axes[0].set_ylabel("Applied B Field (T)")
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_nmr_map_difference(
+    absorption_data_a: np.ndarray,
+    absorption_data_b: np.ndarray,
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    log_scale: bool = True,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Difference map of two NMR maps on a symmetric diverging colour scale.
+
+    Plots (a − b), or log(a) − log(b) when log_scale is True.
+
+    Args:
+        absorption_data_a, absorption_data_b (ndarray): Maps, shape (n_fields, n_freqs).
+        applied_field_list (ndarray): Applied fields in Tesla.
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        log_scale (bool): Difference of logs. Default True.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    if log_scale:
+        difference = np.log(absorption_data_a) - np.log(absorption_data_b)
+    else:
+        difference = absorption_data_a - absorption_data_b
+    scale = np.max(np.abs(difference))
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(
+        difference,
+        origin="lower",
+        cmap=cm.seismic,
+        vmin=-scale,
+        vmax=scale,
+        aspect="auto",
+        extent=_nmr_extent(applied_field_list, rf_freq_list),
+        interpolation="none",
+    )
+    plt.colorbar(im, ax=ax)
+    ax.set_xlabel("RF Frequency (MHz)")
+    ax.set_ylabel("Applied B Field (T)")
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_nmr_map_layered(
+    species_maps: dict[str, np.ndarray],
+    applied_field_list: np.ndarray,
+    rf_freq_list: np.ndarray,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Per-species transparent layers of an experimental NMR simulation.
+
+    Each species' log map is drawn as its own colour layer with decreasing
+    alpha (Greys, Blues, Reds, Greens in dict order), matching the original
+    experimental-simulation figure.
+
+    Args:
+        species_maps (dict): Species name → absorption map, e.g. from
+            qdot.nmr.experimental_nmr_simulation.
+        applied_field_list (ndarray): Applied fields in Tesla.
+        rf_freq_list (ndarray): RF frequencies in Hz.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    cmaps = [cm.Greys, cm.Blues, cm.Reds, cm.Greens]
+    alphas = [1.0, 0.5, 0.25, 0.25]
+    extent = _nmr_extent(applied_field_list, rf_freq_list)
+
+    fig, ax = plt.subplots(figsize=(12, 12))
+    for (species, data), cmap, alpha in zip(species_maps.items(), cmaps, alphas):
+        ax.imshow(
+            np.log(data),
+            origin="lower",
+            cmap=cmap,
+            alpha=alpha,
+            aspect="auto",
+            extent=extent,
+            interpolation="none",
+        )
+    ax.set_xlabel("RF Frequency (MHz)")
+    ax.set_ylabel("Applied B Field (T)")
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Energy level diagrams
+# ---------------------------------------------------------------------------
+
+
+def plot_energy_levels(
+    sweep_values: np.ndarray,
+    level_data: np.ndarray,
+    x_label: str,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Energy level (anti-crossing) diagram over a swept parameter.
+
+    Args:
+        sweep_values (ndarray): Swept variable (e.g. B in Tesla, or η).
+        level_data (ndarray): Eigenenergies in Hz, shape (n_levels, n_sweep),
+            e.g. from qdot.hamiltonians.energy_levels_vs_field.
+        x_label (str): Label of the swept variable.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, ax = plt.subplots()
+    for level in level_data:
+        ax.plot(sweep_values, level / 1e6, color="black", linewidth=0.8)
+    ax.set_xlabel(x_label)
+    ax.set_ylabel("Energy (MHz)")
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_energy_levels_comparison(
+    sweep_values: np.ndarray,
+    faraday_levels: np.ndarray,
+    voigt_levels: np.ndarray,
+    x_label: str = "Applied B Field (T)",
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Two-panel Faraday | Voigt energy level diagram with shared y-limits.
+
+    Args:
+        sweep_values (ndarray): Swept variable.
+        faraday_levels, voigt_levels (ndarray): Eigenenergies in Hz,
+            shape (n_levels, n_sweep). Overlaying several sites is possible by
+            stacking their level arrays along axis 0.
+        x_label (str): Label of the swept variable.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, axes = plt.subplots(1, 2, figsize=(12, 5), sharey=True)
+
+    for ax, levels, geometry, letter in zip(
+        axes, (faraday_levels, voigt_levels), ("Faraday", "Voigt"), "ab"
+    ):
+        for level in levels:
+            ax.plot(sweep_values, level / 1e6, color="black", linewidth=0.5)
+        ax.set_xlabel(x_label)
+        ax.set_title(f"{geometry} Orientation")
+        ax.text(0.02, 0.95, letter, transform=ax.transAxes, fontsize=14)
+
+    axes[0].set_ylabel("Energy (MHz)")
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Quadrupolar site maps and EFG direction quivers
+# ---------------------------------------------------------------------------
+
+
+def plot_site_map(
+    site_data: np.ndarray,
+    colorbar_label: str = "",
+    cmap=cm.GnBu,
+    vmin: float | None = None,
+    vmax: float | None = None,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Generic per-site heatmap with a horizontal colorbar (axes hidden).
+
+    Args:
+        site_data (ndarray): Per-site values, shape (n, m).
+        colorbar_label (str): Label under the colorbar.
+        cmap: Matplotlib colormap. Default GnBu.
+        vmin, vmax (float): Optional fixed colour scale.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, ax = plt.subplots()
+    im = ax.imshow(site_data, cmap=cmap, vmin=vmin, vmax=vmax)
+    ax.axis("off")
+    cbar = plt.colorbar(im, ax=ax, orientation="horizontal")
+    if colorbar_label:
+        cbar.ax.set_xlabel(colorbar_label, fontsize=14)
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_biaxiality(
+    eta: np.ndarray,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """Heatmap of biaxiality η on the standard fixed 0-1 scale."""
+    return plot_site_map(
+        eta,
+        colorbar_label=r"$\eta$",
+        vmin=0.0,
+        vmax=1.0,
+        title=title,
+        save_path=save_path,
+    )
+
+
+def plot_quadrupole_frequency(
+    frequency: np.ndarray,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Heatmap of the quadrupolar frequency across the dot.
+
+    Args:
+        frequency (ndarray): Quadrupolar frequency in Hz, e.g. from
+            qdot.efg.quadrupole_frequency.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    return plot_site_map(
+        frequency / 1e6,
+        colorbar_label="Quadrupole Frequency (MHz)",
+        title=title,
+        save_path=save_path,
+    )
+
+
+def plot_efg_directions(
+    euler_angles: np.ndarray,
+    background: np.ndarray,
+    background_label: str = "",
+    arrow_lengths: np.ndarray | None = None,
+    spacing: int = 20,
+    double_headed: bool = True,
+    background_vmin: float | None = None,
+    background_vmax: float | None = None,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Quiver map of the EFG principal-axis direction over a background heatmap.
+
+    Arrow angles come from the Euler γ angle at each site; arrows are drawn
+    every `spacing` sites. Pass V_ZZ as arrow_lengths to scale arrows by the
+    interaction size, or leave None for unit arrows. Backgrounds used in the
+    original figures: biaxiality η, In concentration, quadrupole frequency.
+
+    Args:
+        euler_angles (ndarray): Euler angles per site, shape (n, m, 3).
+            (Reshape the (n·m, 3) array from load_efg before passing.)
+        background (ndarray): Background values, shape (n, m).
+        background_label (str): Colorbar label.
+        arrow_lengths (ndarray): Optional arrow length per site, shape (n, m).
+        spacing (int): Arrow subsampling interval in sites.
+        double_headed (bool): Draw arrowheads at both ends (the EFG axis has
+            no sign). Default True.
+        background_vmin, background_vmax (float): Optional fixed colour scale.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    n, m = background.shape
+    X, Y = np.meshgrid(np.arange(m), np.arange(n))
+    angles_deg = euler_angles[:, :, 2] * 180 / np.pi
+    lengths = arrow_lengths if arrow_lengths is not None else np.ones((n, m))
+
+    fig, ax = plt.subplots(figsize=(12, 8))
+    s = spacing
+    quiver_kwargs = dict(minshaft=5, pivot="middle", color="black")
+    ax.quiver(
+        X[::s, ::s],
+        Y[::s, ::s],
+        lengths[::s, ::s],
+        lengths[::s, ::s],
+        angles=angles_deg[::s, ::s],
+        **quiver_kwargs,
+    )
+    if double_headed:
+        ax.quiver(
+            X[::s, ::s],
+            Y[::s, ::s],
+            lengths[::s, ::s],
+            lengths[::s, ::s],
+            angles=angles_deg[::s, ::s] + 180,
+            **quiver_kwargs,
+        )
+
+    im = ax.imshow(background, cmap=cm.GnBu, vmin=background_vmin, vmax=background_vmax)
+    ax.axis("off")
+    cbar = plt.colorbar(im, ax=ax, orientation="horizontal")
+    if background_label:
+        cbar.ax.set_xlabel(background_label, fontsize=14)
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Quadrupolar frequency histograms
+# ---------------------------------------------------------------------------
+
+
+def _gauss(x, A, mu, sigma):
+    return A * np.exp(-((x - mu) ** 2) / (2 * sigma**2))
+
+
+def _fit_histogram(values_mhz, bin_centres, hist_vals, fit):
+    """Fit a named distribution to histogram data; return (curve, annotation)."""
+    if fit == "gauss":
+        coeffs, _ = curve_fit(_gauss, bin_centres, hist_vals, p0=[1.0, 0.0, 0.2])
+        fitted = _gauss(bin_centres, *coeffs)
+        ss_res = np.sum((hist_vals - fitted) ** 2)
+        ss_tot = np.sum((hist_vals - np.mean(hist_vals)) ** 2)
+        r2 = 1 - ss_res / ss_tot
+        text = (
+            rf"$\mu$ = {coeffs[1]:.2f}, $\sigma$ = {abs(coeffs[2]):.2f}, "
+            rf"$R^2$ = {r2:.2f}"
+        )
+    elif fit == "maxwell":
+        params = maxwell.fit(values_mhz)
+        fitted = maxwell.pdf(bin_centres, *params)
+        text = f"Maxwell: loc = {params[0]:.2f}, scale = {params[1]:.2f}"
+    elif fit == "gamma":
+        params = gamma_dist.fit(values_mhz, floc=0)
+        fitted = gamma_dist.pdf(bin_centres, *params)
+        text = f"Gamma: a = {params[0]:.2f}, scale = {params[2]:.2f}"
+    else:
+        raise ValueError(
+            f"fit must be 'gauss', 'maxwell', 'gamma' or None, got {fit!r}"
+        )
+    return fitted, text
+
+
+def plot_frequency_histogram(
+    frequencies: np.ndarray,
+    fit: str | None = None,
+    label: str | None = None,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Histogram of per-site quadrupolar frequencies with an optional fitted pdf.
+
+    The Maxwell and gamma fits follow the original analysis and act on the
+    magnitude of the frequencies; the Gaussian fit uses the signed values.
+    Which distributions are physically meaningful is a physics question
+    recorded in human-todo.
+
+    Args:
+        frequencies (ndarray): Per-site frequencies in Hz, e.g.
+            qdot.efg.quadrupole_frequency of a V_ZZ array.
+        fit (str): "gauss", "maxwell", "gamma", or None for no fit.
+        label (str): Optional legend label for the histogram.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    values_mhz = np.asarray(frequencies).flatten() / 1e6
+    if fit in ("maxwell", "gamma"):
+        values_mhz = np.abs(values_mhz)
+
+    fig, ax = plt.subplots()
+    hist_vals, bin_edges, _ = ax.hist(
+        values_mhz, bins="auto", density=True, histtype="step", label=label
+    )
+    bin_centres = (bin_edges[:-1] + bin_edges[1:]) / 2
+
+    if fit is not None:
+        fitted, text = _fit_histogram(values_mhz, bin_centres, hist_vals, fit)
+        ax.plot(bin_centres, fitted, linestyle="dashed")
+        ax.text(
+            0.95,
+            0.95,
+            text,
+            transform=ax.transAxes,
+            ha="right",
+            va="top",
+            fontsize=9,
+            bbox=dict(boxstyle="round", facecolor="white", alpha=0.7),
+        )
+
+    ax.set_xlabel("Quadrupole Frequency (MHz)")
+    ax.set_ylabel("Probability Density")
+    if label:
+        ax.legend()
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_frequency_histograms(
+    frequency_sets: dict[str, np.ndarray],
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Overlaid step histograms of several frequency sets (species or regions).
+
+    Args:
+        frequency_sets (dict): Legend label → per-site frequencies in Hz.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, ax = plt.subplots()
+    for label, frequencies in frequency_sets.items():
+        ax.hist(
+            np.asarray(frequencies).flatten() / 1e6,
+            bins="auto",
+            density=True,
+            histtype="step",
+            label=label,
+        )
+    ax.set_xlabel("Quadrupole Frequency (MHz)")
+    ax.set_ylabel("Probability Density")
+    ax.legend()
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_frequency_histograms_grid(
+    frequency_sets: dict[str, np.ndarray],
+    fit: str | None = "gamma",
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    2×2 grid of fitted frequency histograms, one panel per species.
+
+    Args:
+        frequency_sets (dict): Panel title → per-site frequencies in Hz
+            (up to four entries).
+        fit (str): "gauss", "maxwell", "gamma", or None. Default "gamma".
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, axes = plt.subplots(2, 2, figsize=(12, 10))
+
+    for ax, (label, frequencies) in zip(axes.flatten(), frequency_sets.items()):
+        values_mhz = np.asarray(frequencies).flatten() / 1e6
+        if fit in ("maxwell", "gamma"):
+            values_mhz = np.abs(values_mhz)
+        hist_vals, bin_edges, _ = ax.hist(
+            values_mhz, bins="auto", density=True, histtype="step"
+        )
+        bin_centres = (bin_edges[:-1] + bin_edges[1:]) / 2
+        if fit is not None:
+            fitted, text = _fit_histogram(values_mhz, bin_centres, hist_vals, fit)
+            ax.plot(bin_centres, fitted, linestyle="dashed")
+            ax.text(
+                0.95,
+                0.95,
+                text,
+                transform=ax.transAxes,
+                ha="right",
+                va="top",
+                fontsize=8,
+                bbox=dict(boxstyle="round", facecolor="white", alpha=0.7),
+            )
+        ax.set_title(label)
+
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Measured (Sokolov) strain maps
+# ---------------------------------------------------------------------------
+
+
+def plot_measured_strain(
+    xx_array: np.ndarray,
+    xz_array: np.ndarray,
+    zz_array: np.ndarray,
+    layout: str = "horizontal",
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Three-panel map of measured strain components (the Sokolov paper figure).
+
+    "horizontal" reproduces the paper-recreation layout: panels ordered
+    ε_xx, ε_zz, ε_xz on a fixed ±0.02 scale. "vertical" stacks the panels
+    with a shared data-driven RdBu scale.
+
+    Args:
+        xx_array, xz_array, zz_array (ndarray): Strain components from
+            qdot.io.load_strain_data, shape (n, m).
+        layout (str): "horizontal" or "vertical".
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    panels = [
+        (xx_array, r"$\epsilon_{xx}$"),
+        (zz_array, r"$\epsilon_{zz}$"),
+        (xz_array, r"$\epsilon_{xz}$"),
+    ]
+
+    if layout == "horizontal":
+        fig, axes = plt.subplots(1, 3, figsize=(9, 3), sharey=True)
+        for ax, (data, label) in zip(axes, panels):
+            im = ax.imshow(data, vmin=-0.02, vmax=0.02)
+            ax.axis("off")
+            ax.text(20, 150, label, fontsize=16)
+        cbar_ax = fig.add_axes([0.1, 0.1, 0.5, 0.05])
+        plt.colorbar(im, cax=cbar_ax, orientation="horizontal")
+    elif layout == "vertical":
+        fig, axes = plt.subplots(3, 1, figsize=(6, 9))
+        all_data = np.concatenate([d.ravel() for d, _ in panels])
+        normalizer = Normalize(all_data.min(), all_data.max())
+        for ax, (data, label) in zip(axes, panels):
+            ax.imshow(data, cmap=cm.RdBu, norm=normalizer)
+            ax.axis("off")
+            ax.text(20, 150, label, fontsize=16)
+        plt.colorbar(
+            cm.ScalarMappable(norm=normalizer, cmap=cm.RdBu),
+            ax=axes.ravel().tolist(),
+            shrink=0.95,
+            orientation="vertical",
+        )
+    else:
+        raise ValueError(f"layout must be 'horizontal' or 'vertical', got {layout!r}")
+
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_strain_row_cut(
+    xx_array: np.ndarray,
+    xz_array: np.ndarray,
+    zz_array: np.ndarray,
+    row: int,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Line cut of all three strain components along one pixel row.
+
+    Args:
+        xx_array, xz_array, zz_array (ndarray): Strain components, shape (n, m).
+        row (int): Row index of the cut.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, ax = plt.subplots()
+    for data, label in [
+        (xx_array, r"$\epsilon_{xx}$"),
+        (xz_array, r"$\epsilon_{xz}$"),
+        (zz_array, r"$\epsilon_{zz}$"),
+    ]:
+        ax.plot(data[row], label=label)
+    ax.set_xlabel("Column Index")
+    ax.set_ylabel("Strain")
+    ax.set_title(f"Strain Along Row {row}")
+    ax.legend()
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# NFF and machine gun curves
+# ---------------------------------------------------------------------------
+
+
+def plot_polarisation_curve(
+    dephasing_list: np.ndarray,
+    z_polarisations: np.ndarray,
+    reference: float | None = None,
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Z polarisation against dephasing strength, with the x-axis inverted so
+    dephasing increases left to right (1 = none, 0.5 = maximal).
+
+    Args:
+        dephasing_list (ndarray): Dephasing values, e.g. from
+            qdot.nff.dephasing_polarisation_curve.
+        z_polarisations (ndarray): Z polarisation at each value.
+        reference (float): Optional undephased reference, drawn as a dotted
+            horizontal line (qdot.nff.non_dephased_polarisation).
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, ax = plt.subplots()
+    ax.plot(dephasing_list, np.real(z_polarisations))
+    if reference is not None:
+        ax.axhline(reference, linestyle="dotted", color="grey")
+    ax.invert_xaxis()
+    ax.set_xlabel(r"Dephasing Parameter $\gamma$")
+    ax.set_ylabel("Z Polarisation")
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig
+
+
+def plot_fidelity_curves(
+    error_strengths: np.ndarray,
+    fidelity_curves: dict[str, np.ndarray],
+    x_label: str = "Error Strength",
+    y_label: str = "Fidelity",
+    title: str | None = None,
+    save_path: pathlib.Path | str | None = None,
+) -> plt.Figure:
+    """
+    Machine gun fidelity (or trace distance) against error strength.
+
+    Args:
+        error_strengths (ndarray): Channel strengths swept.
+        fidelity_curves (dict): Legend label → metric values, e.g. one entry
+            per photon count from qdot.machine_gun.fidelity_vs_error.
+        x_label, y_label (str): Axis labels.
+        title (str): Optional figure title.
+        save_path: File path to save. If None, display instead.
+
+    Returns:
+        Figure
+    """
+    fig, ax = plt.subplots()
+    for label, curve in fidelity_curves.items():
+        ax.plot(error_strengths, curve, label=label)
+    ax.set_xlabel(x_label)
+    ax.set_ylabel(y_label)
+    ax.legend()
+    if title:
+        ax.set_title(title)
+    fig.tight_layout()
+    _save_or_show(fig, save_path)
+    return fig

--- a/qdot/sites.py
+++ b/qdot/sites.py
@@ -1,0 +1,89 @@
+"""
+Site sampling utilities for selecting lattice locations within a region.
+
+Locations are (row, column) index pairs into the 2D arrays produced by the
+EFG and strain loaders. Functions take array shapes or strain arrays directly
+so they stay decoupled from any particular archive format.
+"""
+
+import numpy as np
+
+
+def all_locations(shape: tuple[int, int]) -> list[tuple[int, int]]:
+    """
+    Enumerate every lattice site in a region.
+
+    Args:
+        shape (tuple): (n_rows, n_cols) of the region arrays.
+
+    Returns:
+        list of (int, int): All (row, column) index pairs.
+    """
+    n_rows, n_cols = shape
+    return [(i, j) for i in range(n_rows) for j in range(n_cols)]
+
+
+def random_locations(
+    n_locations: int,
+    shape: tuple[int, int],
+    rng: np.random.Generator | int | None = None,
+) -> list[tuple[int, int]]:
+    """
+    Draw lattice sites uniformly at random from a region (with replacement).
+
+    Args:
+        n_locations (int): Number of sites to draw.
+        shape (tuple): (n_rows, n_cols) of the region arrays.
+        rng: numpy Generator, integer seed, or None for fresh entropy.
+
+    Returns:
+        list of (int, int): Random (row, column) index pairs.
+    """
+    rng = np.random.default_rng(rng)
+    rows = rng.integers(shape[0], size=n_locations)
+    cols = rng.integers(shape[1], size=n_locations)
+    return list(zip(rows.tolist(), cols.tolist()))
+
+
+def find_best_locations(
+    n_locations: int,
+    xx_array: np.ndarray,
+    xz_array: np.ndarray,
+    zz_array: np.ndarray,
+    search_range: int,
+    rng: np.random.Generator | int | None = None,
+) -> list[tuple[int, int]]:
+    """
+    Draw random sites and snap each to the local maximum of the summed strain.
+
+    For each random seed site, searches the (2·search_range + 1)² window
+    around it in the metric ε_xx + ε_xz + ε_zz and returns the coordinates of
+    the window maximum, so sampled sites sit on strongly-strained nuclei.
+
+    The plain component sum as a strain metric is inherited from the original
+    research code; see human-todo. before relying on it quantitatively.
+
+    Args:
+        n_locations (int): Number of sites to return.
+        xx_array, xz_array, zz_array (ndarray): Strain components, shape (n, m).
+        search_range (int): Half-width of the search window in sites.
+        rng: numpy Generator, integer seed, or None for fresh entropy.
+
+    Returns:
+        list of (int, int): (row, column) index pairs at local strain maxima.
+    """
+    metric = xx_array + xz_array + zz_array
+    n_rows, n_cols = metric.shape
+
+    best = []
+    for row, col in random_locations(n_locations, metric.shape, rng):
+        row_min = max(row - search_range, 0)
+        row_max = min(row + search_range + 1, n_rows)
+        col_min = max(col - search_range, 0)
+        col_max = min(col + search_range + 1, n_cols)
+
+        window = metric[row_min:row_max, col_min:col_max]
+        rel_row, rel_col = np.unravel_index(np.argmax(window), window.shape)
+        best.append((row_min + int(rel_row), col_min + int(rel_col)))
+
+    return best

--- a/run_new_experiments.py
+++ b/run_new_experiments.py
@@ -1,0 +1,417 @@
+"""
+Run the newly ported experiments against the real Sokolov dataset.
+
+Reads strain/concentration data from real_data/ and the pre-computed EFG
+archives from real-data-outputs/efg/, and writes every figure to
+new_data_outputs/. EFG archives and the concentration file are symlinked
+into new_data_outputs/work/ so the NMR functions see one data directory.
+
+Sizes are chosen to finish in a few minutes on a laptop; raise N_FIELDS /
+N_FREQS / site counts for publication-quality versions.
+"""
+
+import pathlib
+import time
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.signal
+
+import qdot
+from qdot import plot
+
+REPO = pathlib.Path(__file__).parent
+REAL_DATA = REPO / "real_data"
+EFG_DIR = REPO / "real-data-outputs" / "efg"
+OUT = REPO / "new_data_outputs"
+WORK = OUT / "work"
+
+REGION = qdot.SOKOLOV_DOT_REGION  # [100, 1200, 439, 880] -> arrays (441, 1100)
+
+# NMR map resolution
+N_FIELDS = 80
+N_FREQS = 250
+FIELDS = np.linspace(0.001, 2.0, N_FIELDS)  # 0.001 avoids log(0), as in archive
+FREQS = np.linspace(0.0, 75.0, N_FREQS) * 1e6
+N_MAP_SITES = 30
+N_EXPERIMENT_SITES = 80
+N_COMBINED_SITES = 40
+
+
+def setup_work_dir() -> None:
+    WORK.mkdir(parents=True, exist_ok=True)
+    for src in list(EFG_DIR.glob("*.npz")) + [
+        REAL_DATA / "conc_data_to_scale_cubic_interpolation.npy",
+        REAL_DATA / "full_epsilon_xx.txt",
+        REAL_DATA / "full_epsilon_xy.txt",
+        REAL_DATA / "full_epsilon_yy.txt",
+    ]:
+        link = WORK / src.name
+        if not link.exists():
+            link.symlink_to(src.resolve())
+
+
+def log(msg: str) -> None:
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def strain_figures(xx, xz, zz):
+    plot.plot_measured_strain(
+        xx, xz, zz, layout="horizontal", save_path=OUT / "strain_maps_horizontal.png"
+    )
+    plot.plot_measured_strain(
+        xx, xz, zz, layout="vertical", save_path=OUT / "strain_maps_vertical.png"
+    )
+    plot.plot_strain_row_cut(
+        xx, xz, zz, row=xx.shape[0] // 2, save_path=OUT / "strain_row_cut.png"
+    )
+    log("strain figures done")
+
+
+def quadrupolar_figures(efg_data):
+    b_field_maps = []
+    freq_sets = {}
+    for species in ("Ga69", "Ga71", "As75", "In115"):
+        eta, _, _, V_ZZ, euler = efg_data[species]
+        freq = qdot.quadrupole_frequency(species, V_ZZ)
+        freq_sets[species] = freq
+        b_field_maps.append(qdot.equivalent_b_field(species, V_ZZ))
+
+        plot.plot_quadrupole_frequency(
+            freq,
+            title=f"Quadrupole Frequency — {species}",
+            save_path=OUT / f"quadrupole_frequency_{species}.png",
+        )
+        plot.plot_biaxiality(
+            eta,
+            title=f"Biaxiality — {species}",
+            save_path=OUT / f"biaxiality_{species}.png",
+        )
+
+    plot.plot_all_equivalent_b_fields(
+        b_field_maps,
+        region_bounds=REGION,
+        save_path=OUT / "equivalent_b_fields_all_species.png",
+    )
+
+    # EFG direction quivers for In115: eta background and strength background.
+    eta, _, _, V_ZZ, euler = efg_data["In115"]
+    n, m = eta.shape
+    euler_grid = euler.reshape(n, m, 3)
+    plot.plot_efg_directions(
+        euler_grid,
+        eta,
+        background_label=r"$\eta$",
+        background_vmin=0.0,
+        background_vmax=1.0,
+        spacing=25,
+        title="EFG Direction over Biaxiality — In115",
+        save_path=OUT / "efg_directions_biaxiality_In115.png",
+    )
+    plot.plot_efg_directions(
+        euler_grid,
+        np.abs(qdot.quadrupole_frequency("In115", V_ZZ)) / 1e6,
+        background_label="|Quadrupole Frequency| (MHz)",
+        arrow_lengths=np.abs(V_ZZ),
+        spacing=25,
+        title="EFG Direction over Interaction Strength — In115",
+        save_path=OUT / "efg_directions_strength_In115.png",
+    )
+
+    plot.plot_frequency_histograms(
+        freq_sets,
+        title="Quadrupole Frequency Distributions",
+        save_path=OUT / "frequency_histograms_overlay.png",
+    )
+    plot.plot_frequency_histograms_grid(
+        freq_sets, fit="gamma", save_path=OUT / "frequency_histograms_gamma_grid.png"
+    )
+    log("quadrupolar figures done")
+
+
+def energy_level_figures(efg_data):
+    sweep = np.linspace(0.0, 3.0, 120)
+    site = (220, 550)  # central dot site
+
+    for species in ("Ga69", "Ga71", "As75", "In115"):
+        eta, _, _, V_ZZ, euler = efg_data[species]
+        n_cols = eta.shape[1]
+        angles = euler[site[0] * n_cols + site[1]]
+        faraday = qdot.energy_levels_vs_field(
+            species, sweep, eta[site], V_ZZ[site], angles, "Faraday"
+        )
+        voigt = qdot.energy_levels_vs_field(
+            species, sweep, eta[site], V_ZZ[site], angles, "Voigt"
+        )
+        plot.plot_energy_levels_comparison(
+            sweep,
+            faraday,
+            voigt,
+            save_path=OUT / f"energy_levels_comparison_{species}.png",
+        )
+
+    # Random-site ensemble for In115: inhomogeneous level broadening.
+    eta, _, _, V_ZZ, euler = efg_data["In115"]
+    n, m = eta.shape
+    rng = np.random.default_rng(0)
+    sites = qdot.random_locations(10, (n, m), rng=rng)
+    far_stack, voi_stack = [], []
+    for x, y in sites:
+        angles = euler[x * m + y]
+        far_stack.append(
+            qdot.energy_levels_vs_field(
+                "In115", sweep, eta[x, y], V_ZZ[x, y], angles, "Faraday"
+            )
+        )
+        voi_stack.append(
+            qdot.energy_levels_vs_field(
+                "In115", sweep, eta[x, y], V_ZZ[x, y], angles, "Voigt"
+            )
+        )
+    plot.plot_energy_levels_comparison(
+        sweep,
+        np.vstack(far_stack),
+        np.vstack(voi_stack),
+        save_path=OUT / "energy_levels_random_sites_In115.png",
+    )
+
+    # Quadrupolar-only eta sweep at the regional mean V_ZZ.
+    etas = np.linspace(0.0, 1.0, 100)
+    levels = qdot.energy_levels_vs_eta("In115", etas, V_ZZ=float(np.mean(V_ZZ)))
+    plot.plot_energy_levels(
+        etas,
+        levels,
+        x_label=r"Biaxiality $\eta$",
+        title="In115 Levels vs Biaxiality (B = 0)",
+        save_path=OUT / "energy_levels_vs_eta_In115.png",
+    )
+    log("energy level figures done")
+
+
+def nmr_map_figures(map_sites):
+    faraday = qdot.absorption_map(
+        "Ga69", FIELDS, "Faraday", FREQS, map_sites, WORK, REGION
+    )
+    log("Ga69 Faraday map done")
+    voigt = qdot.absorption_map("Ga69", FIELDS, "Voigt", FREQS, map_sites, WORK, REGION)
+    log("Ga69 Voigt map done")
+    qdot.save_nmr_map(
+        WORK, "Ga69", "Faraday", REGION, faraday, FIELDS, FREQS, map_sites
+    )
+    qdot.save_nmr_map(WORK, "Ga69", "Voigt", REGION, voigt, FIELDS, FREQS, map_sites)
+
+    plot.plot_nmr_map(
+        faraday,
+        FIELDS,
+        FREQS,
+        title=f"Ga69 NMR — Faraday, {len(map_sites)} sites",
+        save_path=OUT / "nmr_map_Ga69_Faraday.png",
+    )
+    plot.plot_nmr_map_pair(
+        faraday,
+        voigt,
+        ("Faraday", "Voigt"),
+        FIELDS,
+        FREQS,
+        save_path=OUT / "nmr_map_pair_Ga69_geometries.png",
+    )
+    plot.plot_nmr_map_difference(
+        faraday,
+        voigt,
+        FIELDS,
+        FREQS,
+        title="Ga69: log(Faraday) − log(Voigt)",
+        save_path=OUT / "nmr_map_difference_Ga69_geometries.png",
+    )
+
+    in115 = qdot.absorption_map(
+        "In115", FIELDS, "Faraday", FREQS, map_sites, WORK, REGION
+    )
+    plot.plot_nmr_map(
+        in115,
+        FIELDS,
+        FREQS,
+        title=f"In115 NMR — Faraday, {len(map_sites)} sites",
+        save_path=OUT / "nmr_map_In115_Faraday.png",
+    )
+    log("NMR map figures done")
+
+
+def experimental_simulation_figures():
+    maps = qdot.experimental_nmr_simulation(
+        "Faraday", FIELDS, FREQS, N_EXPERIMENT_SITES, WORK, REGION, rng=1
+    )
+    total = sum(maps.values())
+    plot.plot_nmr_map(
+        total,
+        FIELDS,
+        FREQS,
+        title=f"Experimental Estimate — Faraday, {N_EXPERIMENT_SITES} nuclei",
+        save_path=OUT / "experimental_nmr_summed.png",
+    )
+    plot.plot_nmr_map_layered(
+        maps,
+        FIELDS,
+        FREQS,
+        title="Experimental Estimate — per-species layers",
+        save_path=OUT / "experimental_nmr_layered.png",
+    )
+    log("experimental simulation figures done")
+
+
+def pulse_analysis_figures():
+    freqs = np.linspace(0.0, 100.0, 2000) * 1e6
+    sites = qdot.random_locations(
+        N_COMBINED_SITES, (441, 1100), rng=2
+    )  # EFG array shape for the dot region
+    spectrum = qdot.combined_spectrum(3.0, "Faraday", freqs, sites, WORK, REGION)
+
+    peak_idx, _ = scipy.signal.find_peaks(spectrum, prominence=0.01)
+    main_peak = freqs[peak_idx[np.argmax(spectrum[peak_idx])]]
+
+    # Combined spectrum with detected peaks marked.
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.plot(freqs / 1e6, spectrum)
+    ax.plot(freqs[peak_idx] / 1e6, spectrum[peak_idx], "x", color="red")
+    ax.set_xlabel("RF Frequency (MHz)")
+    ax.set_ylabel("Absorption (arb. units)")
+    ax.set_title(
+        f"Combined Species Spectrum — 3 T, {N_COMBINED_SITES} nuclei per species"
+    )
+    fig.tight_layout()
+    fig.savefig(OUT / "combined_spectrum_peaks.png")
+    plt.close(fig)
+
+    # Pulse overlaid on the spectrum at the main peak.
+    width = 5e6
+    pulse = qdot.lorentzian_pulse(freqs, main_peak, width)
+    pulse = pulse / np.max(pulse)
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.plot(freqs / 1e6, pulse, linestyle="dotted", label="Pulse")
+    ax.plot(freqs / 1e6, spectrum * pulse, label="Pulse × Spectrum")
+    ax.plot(freqs / 1e6, spectrum, alpha=0.3, label="Spectrum")
+    ax.set_xlabel("RF Frequency (MHz)")
+    ax.set_title(f"Lorentzian Pulse at {main_peak / 1e6:.1f} ± {width / 2e6:.1f} MHz")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(OUT / "pulse_overlaid_spectrum.png")
+    plt.close(fig)
+
+    # Capture fraction vs pulse width: in the target window around the main
+    # peak vs the whole spectrum.
+    widths = np.linspace(0.5, 20.0, 40) * 1e6
+    window = (main_peak - 2.5e6, main_peak + 2.5e6)
+    in_band = [
+        qdot.pulse_capture_fraction(spectrum, freqs, main_peak, w, window=window)
+        for w in widths
+    ]
+    overall = [
+        qdot.pulse_capture_fraction(spectrum, freqs, main_peak, w) for w in widths
+    ]
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(widths / 1e6, in_band, label="Target window (peak ± 2.5 MHz)")
+    ax.plot(widths / 1e6, overall, label="Whole spectrum")
+    ax.set_xlabel("Pulse Width (MHz)")
+    ax.set_ylabel("Captured Fraction")
+    ax.set_title(f"Pulse Selectivity at {main_peak / 1e6:.1f} MHz")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(OUT / "pulse_capture_fraction_vs_width.png")
+    plt.close(fig)
+    log("pulse analysis figures done")
+
+
+def mirrored_data_figures():
+    qdot.create_mirrored_strain_data(WORK, REGION, "left_right")
+    qdot.create_mirrored_concentration_data(WORK, REGION, "left_right")
+    xx_m, xz_m, zz_m = qdot.load_mirrored_data(WORK, REGION, mirror_type="left_right")
+    plot.plot_measured_strain(
+        xx_m,
+        xz_m,
+        zz_m,
+        layout="vertical",
+        save_path=OUT / "mirrored_strain_maps_left_right.png",
+    )
+    conc_m = qdot.load_mirrored_concentration_data(WORK, REGION, "left_right")
+    plot.plot_concentration(
+        conc_m, save_path=OUT / "mirrored_concentration_left_right.png"
+    )
+    log("mirrored data figures done")
+
+
+def machine_gun_and_nff_figures():
+    strengths = np.linspace(0.0, 1.0, 25)
+    dephasing_curves = {
+        f"{n} photon{'s' if n > 1 else ''}": qdot.fidelity_vs_error(
+            n, strengths, "dephasing"
+        )
+        for n in (1, 2, 3)
+    }
+    plot.plot_fidelity_curves(
+        strengths,
+        dephasing_curves,
+        x_label="Dephasing Strength",
+        title="Machine Gun Fidelity under Dot Dephasing",
+        save_path=OUT / "machine_gun_fidelity_dephasing.png",
+    )
+    damping_curves = {
+        f"{n} photon{'s' if n > 1 else ''}": qdot.fidelity_vs_error(
+            n, strengths, "damping"
+        )
+        for n in (1, 2, 3)
+    }
+    plot.plot_fidelity_curves(
+        strengths,
+        damping_curves,
+        x_label="Damping Strength",
+        title="Machine Gun Fidelity under Amplitude Damping",
+        save_path=OUT / "machine_gun_fidelity_damping.png",
+    )
+
+    dephasing_list, z_pol = qdot.dephasing_polarisation_curve(0.9, 0.3)
+    reference = qdot.non_dephased_polarisation(0.9, 0.3)
+    plot.plot_polarisation_curve(
+        dephasing_list,
+        z_pol,
+        reference=reference,
+        title="NFF Polarisation, q0 = 0.9, phase = 0.3",
+        save_path=OUT / "nff_polarisation_curve.png",
+    )
+    log("machine gun and NFF figures done")
+
+
+def main():
+    start = time.time()
+    OUT.mkdir(exist_ok=True)
+    setup_work_dir()
+
+    log("loading strain data")
+    xx, xz, zz = qdot.load_strain_data(REAL_DATA, REGION)
+    strain_figures(xx, xz, zz)
+
+    log("loading EFG archives")
+    efg_data = {
+        s: qdot.load_efg(WORK, s, REGION) for s in ("Ga69", "Ga71", "As75", "In115")
+    }
+    quadrupolar_figures(efg_data)
+    energy_level_figures(efg_data)
+
+    log("selecting NMR sites via find_best_locations")
+    map_sites = qdot.find_best_locations(
+        N_MAP_SITES, xx, xz, zz, search_range=25, rng=0
+    )
+    nmr_map_figures(map_sites)
+    experimental_simulation_figures()
+    pulse_analysis_figures()
+    mirrored_data_figures()
+    machine_gun_and_nff_figures()
+
+    n_figures = len(list(OUT.glob("*.png")))
+    log(f"ALL DONE: {n_figures} figures in {OUT} ({time.time() - start:.0f}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_correlators.py
+++ b/tests/test_correlators.py
@@ -119,3 +119,32 @@ def test_run_correlator_series_values_are_finite(efg_dir):
 def test_run_correlator_series_invalid_species_raises(efg_dir):
     with pytest.raises(ValueError, match="nuclear_species"):
         run_correlator_series(efg_dir, np.array([0.0]), 1.0, "Xx99", _BOUNDS)
+
+
+# ---------------------------------------------------------------------------
+# load_correlator_archive
+# ---------------------------------------------------------------------------
+
+
+def test_load_correlator_archive_round_trip(tmp_path):
+    from qdot.correlators import load_correlator_archive
+
+    rng = np.random.default_rng(0)
+    timerange = np.logspace(-6, -3, 8)
+    bounds = [0, 2, 0, 2]
+    species_data = {
+        s: rng.random((3, len(timerange))) for s in ("Ga69", "Ga71", "As75", "In115")
+    }
+    path = tmp_path / "correlator_archive.npz"
+    np.savez(
+        path,
+        timerange=timerange,
+        region_bounds=bounds,
+        **{f"{s}_data": d for s, d in species_data.items()},
+    )
+
+    result = load_correlator_archive(path)
+    np.testing.assert_allclose(result["timerange"], timerange)
+    np.testing.assert_array_equal(result["region_bounds"], bounds)
+    for s, d in species_data.items():
+        np.testing.assert_allclose(result["data"][s], d)

--- a/tests/test_efg.py
+++ b/tests/test_efg.py
@@ -329,3 +329,35 @@ def test_euler_angles_reconstruct_rotation_all_species(species):
                 atol=1e-10,
                 err_msg=f"{species}: Euler reconstruction failed at ({i},{j})",
             )
+
+
+# ---------------------------------------------------------------------------
+# Quadrupole frequency and equivalent B field
+# ---------------------------------------------------------------------------
+
+
+def test_quadrupole_frequency_scales_with_coupling():
+    from qdot.efg import quadrupole_frequency
+    from qdot.isotopes import species_dict, quadrupole_coupling
+
+    V_ZZ = np.array([[1e20, 2e20], [3e20, -4e20]])
+    result = quadrupole_frequency("As75", V_ZZ)
+    expected = quadrupole_coupling(species_dict["As75"]) * V_ZZ
+    np.testing.assert_allclose(result, expected)
+
+
+def test_quadrupole_frequency_invalid_species_raises():
+    from qdot.efg import quadrupole_frequency
+
+    with pytest.raises(ValueError, match="nuclear_species"):
+        quadrupole_frequency("Fe56", np.ones((2, 2)))
+
+
+def test_equivalent_b_field_is_frequency_over_zeeman():
+    from qdot.efg import quadrupole_frequency, equivalent_b_field
+    from qdot.isotopes import species_dict
+
+    V_ZZ = np.array([[1e20, 5e20]])
+    freq = quadrupole_frequency("In115", V_ZZ)
+    expected = freq / species_dict["In115"]["zeeman_frequency_per_tesla"]
+    np.testing.assert_allclose(equivalent_b_field("In115", V_ZZ), expected)

--- a/tests/test_hamiltonians.py
+++ b/tests/test_hamiltonians.py
@@ -126,3 +126,61 @@ def test_transition_rate_on_resonance_exceeds_off_resonance():
         H_rf, states[0], states[1], energies[0], energies[1], gap * 1000
     )
     assert rate_on > rate_off
+
+
+# ---------------------------------------------------------------------------
+# Energy level sweeps
+# ---------------------------------------------------------------------------
+
+
+def test_energy_levels_vs_field_shape():
+    from qdot.hamiltonians import energy_levels_vs_field
+
+    fields = np.linspace(0, 2, 5)
+    levels = energy_levels_vs_field("Ga69", fields, 0.4, 3e20, (0.1, 0.2, 0.3))
+    assert levels.shape == (4, 5)  # spin 3/2 → 4 levels
+
+
+def test_energy_levels_vs_field_pure_zeeman_is_linear():
+    from qdot.hamiltonians import energy_levels_vs_field
+    from qdot.isotopes import species_dict
+
+    fields = np.linspace(0.5, 2.0, 4)
+    levels = energy_levels_vs_field("Ga69", fields, 0.0, 0.0, (0.0, 0.0, 0.0))
+
+    zeeman = species_dict["Ga69"]["zeeman_frequency_per_tesla"]
+    expected = np.outer([-1.5, -0.5, 0.5, 1.5], zeeman * fields)
+    np.testing.assert_allclose(levels, expected, rtol=1e-9)
+
+
+def test_energy_levels_vs_field_invalid_geometry_raises():
+    from qdot.hamiltonians import energy_levels_vs_field
+
+    with pytest.raises(ValueError, match="field_geometry"):
+        energy_levels_vs_field(
+            "Ga69", np.array([1.0]), 0.0, 0.0, (0, 0, 0), field_geometry="Diagonal"
+        )
+
+
+def test_energy_levels_vs_eta_shape_and_zero_field_degeneracy():
+    from qdot.hamiltonians import energy_levels_vs_eta
+
+    etas = np.linspace(0, 1, 6)
+    levels = energy_levels_vs_eta("In115", etas, applied_field=0.0)
+    assert levels.shape == (10, 6)  # spin 9/2 → 10 levels
+
+    # At B = 0 and eta = 0 the quadrupolar Hamiltonian only depends on I_z²,
+    # so levels come in ±m pairs.
+    at_eta_zero = np.sort(levels[:, 0])
+    np.testing.assert_allclose(at_eta_zero[0::2], at_eta_zero[1::2], rtol=1e-9)
+
+
+def test_energy_levels_vs_field_faraday_voigt_differ():
+    from qdot.hamiltonians import energy_levels_vs_field
+
+    fields = np.linspace(0.1, 1.0, 3)
+    faraday = energy_levels_vs_field(
+        "Ga69", fields, 0.5, 3e20, (0.3, 0.6, 0.9), "Faraday"
+    )
+    voigt = energy_levels_vs_field("Ga69", fields, 0.5, 3e20, (0.3, 0.6, 0.9), "Voigt")
+    assert not np.allclose(faraday, voigt)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -160,3 +160,201 @@ class TestLoadEfg:
         save_efg(tmp_path, "As75", BOUNDS, 1, *_make_efg_arrays())
         eta, *_ = load_efg(str(tmp_path), "As75", BOUNDS, 1)
         assert eta.shape == SHAPE
+
+
+# ---------------------------------------------------------------------------
+# Region catalogue and rectangle conversion
+# ---------------------------------------------------------------------------
+
+
+def test_sokolov_regions_contains_dot_region():
+    from qdot.io import SOKOLOV_REGIONS, SOKOLOV_DOT_REGION
+
+    assert SOKOLOV_REGIONS["entire_dot"] == SOKOLOV_DOT_REGION
+    for bounds in SOKOLOV_REGIONS.values():
+        left, right, top, bottom = bounds
+        assert left < right and top < bottom
+
+
+def test_region_from_rectangle():
+    from qdot.io import region_from_rectangle
+
+    result = region_from_rectangle([100, 1200, 200, 1000], [50, 30, 200, 100])
+    assert result == [150, 350, 230, 330]
+
+
+# ---------------------------------------------------------------------------
+# Mirrored datasets
+# ---------------------------------------------------------------------------
+
+
+class TestMirrorArray:
+    def test_left_right_keeps_left_half(self):
+        from qdot.io import mirror_array
+
+        data = np.arange(12.0).reshape(3, 4)
+        result = mirror_array(data, "left_right")
+        np.testing.assert_array_equal(result[:, :2], data[:, :2])
+        np.testing.assert_array_equal(result, np.fliplr(result))
+
+    def test_right_left_keeps_right_half(self):
+        from qdot.io import mirror_array
+
+        data = np.arange(12.0).reshape(3, 4)
+        result = mirror_array(data, "right_left")
+        np.testing.assert_array_equal(result[:, 2:], data[:, 2:])
+        np.testing.assert_array_equal(result, np.fliplr(result))
+
+    def test_odd_columns_drop_centre(self):
+        from qdot.io import mirror_array
+
+        data = np.arange(15.0).reshape(3, 5)
+        assert mirror_array(data, "left_right").shape == (3, 4)
+
+    def test_invalid_direction_raises(self):
+        from qdot.io import mirror_array
+
+        with pytest.raises(ValueError, match="direction"):
+            mirror_array(np.zeros((2, 2)), "top_bottom")
+
+
+class TestMirroredDatasets:
+    def test_strain_round_trip(self, strain_dir):
+        from qdot.io import (
+            create_mirrored_strain_data,
+            load_mirrored_data,
+            load_strain_data,
+            mirror_array,
+        )
+
+        d, *_ = strain_dir
+        bounds = [0, 8, 0, 6]
+        create_mirrored_strain_data(d, bounds, "left_right")
+
+        xx_m, xz_m, zz_m = load_mirrored_data(d, bounds, mirror_type="left_right")
+        xx, xz, zz = load_strain_data(d, bounds)
+        np.testing.assert_allclose(xx_m, mirror_array(xx, "left_right"))
+        np.testing.assert_allclose(xz_m, mirror_array(xz, "left_right"))
+        np.testing.assert_allclose(zz_m, mirror_array(zz, "left_right"))
+
+    def test_strain_skips_existing(self, strain_dir):
+        from qdot.io import create_mirrored_strain_data, load_mirrored_data
+
+        d, *_ = strain_dir
+        bounds = [0, 8, 0, 6]
+        create_mirrored_strain_data(d, bounds)
+        first, *_ = load_mirrored_data(d, bounds)
+
+        # Overwrite the source files; without overwrite=True the archive
+        # must stay unchanged.
+        rng = np.random.default_rng(99)
+        _write_strain_files(
+            d,
+            rng.random((10, 10)),
+            rng.random((10, 10)),
+            rng.random((10, 10)),
+        )
+        create_mirrored_strain_data(d, bounds)
+        unchanged, *_ = load_mirrored_data(d, bounds)
+        np.testing.assert_array_equal(first, unchanged)
+
+        create_mirrored_strain_data(d, bounds, overwrite=True)
+        replaced, *_ = load_mirrored_data(d, bounds)
+        assert not np.array_equal(first, replaced)
+
+    def test_concentration_round_trip(self, tmp_path):
+        from qdot.io import (
+            create_mirrored_concentration_data,
+            load_mirrored_concentration_data,
+            mirror_array,
+        )
+
+        rng = np.random.default_rng(3)
+        conc = rng.uniform(0, 0.5, (10, 10))
+        np.save(tmp_path / "conc_data_to_scale_cubic_interpolation.npy", conc)
+
+        bounds = [0, 8, 0, 6]
+        create_mirrored_concentration_data(tmp_path, bounds, "right_left")
+        result = load_mirrored_concentration_data(tmp_path, bounds, "right_left")
+        np.testing.assert_allclose(result, mirror_array(conc[0:6, 0:8], "right_left"))
+
+
+# ---------------------------------------------------------------------------
+# NMR map archives
+# ---------------------------------------------------------------------------
+
+
+class TestNmrMapArchive:
+    _FIELDS = np.linspace(0.1, 2.0, 4)
+    _FREQS = np.linspace(1e6, 50e6, 6)
+    _LOCS = [(0, 0), (1, 1)]
+    _BOUNDS = [0, 2, 0, 2]
+
+    def _save(self, d, data, **kwargs):
+        from qdot.io import save_nmr_map
+
+        save_nmr_map(
+            d,
+            "Ga69",
+            "Faraday",
+            self._BOUNDS,
+            data,
+            self._FIELDS,
+            self._FREQS,
+            self._LOCS,
+            **kwargs,
+        )
+
+    def test_round_trip(self, tmp_path):
+        from qdot.io import load_nmr_map
+
+        data = np.random.default_rng(0).random((4, 6))
+        self._save(tmp_path, data)
+
+        loaded, fields, freqs, locs = load_nmr_map(
+            tmp_path, "Ga69", "Faraday", 2, self._BOUNDS, self._FIELDS, self._FREQS
+        )
+        np.testing.assert_allclose(loaded, data)
+        np.testing.assert_allclose(fields, self._FIELDS)
+        np.testing.assert_allclose(freqs, self._FREQS)
+        np.testing.assert_array_equal(locs, self._LOCS)
+
+    def test_skips_existing_unless_overwrite(self, tmp_path):
+        from qdot.io import load_nmr_map
+
+        first = np.ones((4, 6))
+        second = np.full((4, 6), 2.0)
+        self._save(tmp_path, first)
+        self._save(tmp_path, second)
+        loaded, *_ = load_nmr_map(
+            tmp_path, "Ga69", "Faraday", 2, self._BOUNDS, self._FIELDS, self._FREQS
+        )
+        np.testing.assert_allclose(loaded, first)
+
+        self._save(tmp_path, second, overwrite=True)
+        loaded, *_ = load_nmr_map(
+            tmp_path, "Ga69", "Faraday", 2, self._BOUNDS, self._FIELDS, self._FREQS
+        )
+        np.testing.assert_allclose(loaded, second)
+
+    def test_sundfors_variant_has_separate_file(self, tmp_path):
+        from qdot.io import load_nmr_map
+
+        self._save(tmp_path, np.ones((4, 6)))
+        self._save(tmp_path, np.full((4, 6), 3.0), use_sundfors=True)
+
+        standard, *_ = load_nmr_map(
+            tmp_path, "Ga69", "Faraday", 2, self._BOUNDS, self._FIELDS, self._FREQS
+        )
+        sundfors, *_ = load_nmr_map(
+            tmp_path,
+            "Ga69",
+            "Faraday",
+            2,
+            self._BOUNDS,
+            self._FIELDS,
+            self._FREQS,
+            use_sundfors=True,
+        )
+        np.testing.assert_allclose(standard, np.ones((4, 6)))
+        np.testing.assert_allclose(sundfors, np.full((4, 6), 3.0))

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -43,3 +43,21 @@ def test_checkhovich_ga69_s11_is_negative():
 def test_zeeman_frequencies_positive():
     for key in ALL_SPECIES:
         assert species_dict[key]["zeeman_frequency_per_tesla"] > 0
+
+
+def test_quadrupole_coupling_matches_formula():
+    import scipy.constants as const
+    from qdot.isotopes import species_dict, quadrupole_coupling
+
+    species = species_dict["Ga69"]
+    spin = species["particle_spin"]
+    Q = species["quadrupole_moment"]
+    expected = (3 * const.e * Q) / (2 * const.h * spin * (2 * spin - 1))
+    assert quadrupole_coupling(species) == pytest.approx(expected)
+
+
+def test_quadrupole_coupling_positive_for_all_species():
+    from qdot.isotopes import species_dict, quadrupole_coupling
+
+    for species in species_dict.values():
+        assert quadrupole_coupling(species) > 0

--- a/tests/test_machine_gun.py
+++ b/tests/test_machine_gun.py
@@ -203,3 +203,96 @@ def test_machine_gun_with_errors_output_shape():
     errors = np.zeros((n, 2), dtype=int)
     op = machine_gun_with_pauli_errors(n, errors)
     assert op.shape == (2 ** (n + 1), 2 ** (n + 1))
+
+
+# ---------------------------------------------------------------------------
+# Density-matrix formulation with error channels
+# ---------------------------------------------------------------------------
+
+
+def test_initial_density_matrix_is_ground_state_projector():
+    from qdot.machine_gun import initial_density_matrix
+
+    dm = initial_density_matrix(2)
+    full = dm.full()
+    assert full.shape == (8, 8)
+    assert full[0, 0] == pytest.approx(1.0)
+    assert np.sum(np.abs(full)) == pytest.approx(1.0)
+
+
+def test_perfect_density_matrix_matches_state_vector_path():
+    from qdot.machine_gun import (
+        perfect_machine_gun_density_matrix,
+        operational_perfect_machine_gun,
+        state_to_density_matrix,
+    )
+
+    state = operational_perfect_machine_gun(2)
+    expected = state_to_density_matrix(state.flatten())
+    result = perfect_machine_gun_density_matrix(2).full()
+    np.testing.assert_allclose(result, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("channel", ["dephasing", "damping"])
+def test_zero_error_strength_matches_perfect(channel):
+    from qdot.machine_gun import noisy_machine_gun, perfect_machine_gun_density_matrix
+
+    noisy = noisy_machine_gun(2, channel, 0.0).full()
+    perfect = perfect_machine_gun_density_matrix(2).full()
+    np.testing.assert_allclose(noisy, perfect, atol=1e-12)
+
+
+@pytest.mark.parametrize("channel", ["dephasing", "damping"])
+@pytest.mark.parametrize("strength", [0.3, 0.7, 1.0])
+def test_noisy_machine_gun_preserves_trace(channel, strength):
+    from qdot.machine_gun import noisy_machine_gun
+
+    dm = noisy_machine_gun(2, channel, strength)
+    assert dm.tr() == pytest.approx(1.0, abs=1e-10)
+
+
+def test_invalid_channel_raises():
+    from qdot.machine_gun import noisy_machine_gun
+
+    with pytest.raises(ValueError, match="error_channel"):
+        noisy_machine_gun(2, "depolarising", 0.5)
+
+
+def test_fidelity_starts_at_one_and_decreases():
+    from qdot.machine_gun import fidelity_vs_error
+
+    strengths = np.array([0.0, 0.5, 1.0])
+    fidelities = fidelity_vs_error(2, strengths, "dephasing")
+    assert fidelities[0] == pytest.approx(1.0, abs=1e-6)
+    assert fidelities[-1] < fidelities[0]
+
+
+def test_trace_distance_starts_at_zero_and_increases():
+    from qdot.machine_gun import trace_distance_vs_error
+
+    strengths = np.array([0.0, 1.0])
+    distances = trace_distance_vs_error(2, strengths, "damping")
+    assert distances[0] == pytest.approx(0.0, abs=1e-6)
+    assert distances[-1] > distances[0]
+
+
+def test_error_list_to_array():
+    from qdot.machine_gun import error_list_to_array
+
+    result = error_list_to_array([(1, "Z"), (3, "X")], n_photons=3)
+    expected = np.array([[1, 4], [0, 0], [1, 2]])
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_error_list_to_array_validates_label():
+    from qdot.machine_gun import error_list_to_array
+
+    with pytest.raises(ValueError, match="label"):
+        error_list_to_array([(1, "W")], n_photons=2)
+
+
+def test_error_list_to_array_validates_index():
+    from qdot.machine_gun import error_list_to_array
+
+    with pytest.raises(ValueError, match="photon_index"):
+        error_list_to_array([(3, "X")], n_photons=2)

--- a/tests/test_nff.py
+++ b/tests/test_nff.py
@@ -134,3 +134,41 @@ def test_non_dephased_polarisation_matches_curve_at_no_dephasing():
     result = non_dephased_polarisation(q0, phase)
     _, z_list = dephasing_polarisation_curve(q0, phase, n_gammas=1)
     assert abs(result - z_list[0]) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# X/Y polarisation and the scattering-probability relation
+# ---------------------------------------------------------------------------
+
+
+def test_x_polarisation_of_plus_state_is_one():
+    from qdot.nff import x_polarisation
+
+    plus_dm = qutip.Qobj(np.array([[1, 1], [1, 1]]) / 2)
+    assert np.real(x_polarisation(plus_dm)) == pytest.approx(1.0)
+
+
+def test_y_polarisation_of_plus_state_is_zero():
+    from qdot.nff import y_polarisation
+
+    plus_dm = qutip.Qobj(np.array([[1, 1], [1, 1]]) / 2)
+    assert abs(y_polarisation(plus_dm)) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_polarisations_of_maximally_mixed_state_are_zero():
+    from qdot.nff import x_polarisation, y_polarisation
+
+    mixed = qutip.Qobj(np.eye(2) / 2)
+    assert abs(x_polarisation(mixed)) == pytest.approx(0.0, abs=1e-12)
+    assert abs(y_polarisation(mixed)) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_dephasing_from_scattering_limits():
+    from qdot.nff import dephasing_from_scattering
+
+    assert dephasing_from_scattering(0.0) == pytest.approx(1.0)
+    assert dephasing_from_scattering(1.0) == pytest.approx(0.5)
+    # Monotonic decrease between the limits.
+    probs = np.linspace(0, 1, 11)
+    values = np.array([dephasing_from_scattering(p) for p in probs])
+    assert np.all(np.diff(values) < 0)

--- a/tests/test_nmr.py
+++ b/tests/test_nmr.py
@@ -130,3 +130,193 @@ class TestVariedFieldSpectra:
             _SPECIES, [1.0, 2.0], "Faraday", _RF_FREQS, _LOCATION, efg_dir, _BOUNDS
         )
         assert not np.array_equal(result[0]["data"], result[1]["data"])
+
+
+# ---------------------------------------------------------------------------
+# Multi-site engine: absorption_map / summed_absorption_spectrum
+# ---------------------------------------------------------------------------
+
+_LOCS = [(0, 0), (0, 1), (1, 1)]
+_SMALL_FIELDS = np.array([0.5, 1.0])
+
+
+class TestAbsorptionMap:
+    def test_shape(self, efg_dir):
+        from qdot.nmr import absorption_map
+
+        result = absorption_map(
+            _SPECIES,
+            _SMALL_FIELDS,
+            "Faraday",
+            _RF_FREQS,
+            _LOCS,
+            efg_dir,
+            _BOUNDS,
+            processes=2,
+        )
+        assert result.shape == (len(_SMALL_FIELDS), len(_RF_FREQS))
+
+    def test_matches_sum_of_single_site_spectra(self, efg_dir):
+        from qdot.nmr import summed_absorption_spectrum
+
+        summed = summed_absorption_spectrum(
+            _SPECIES, 1.0, "Faraday", _RF_FREQS, _LOCS, efg_dir, _BOUNDS, processes=2
+        )
+        expected = np.zeros(len(_RF_FREQS))
+        for loc in _LOCS:
+            expected += absorption_spectrum(
+                _SPECIES, 1.0, "Faraday", _RF_FREQS, loc, efg_dir, _BOUNDS
+            )
+        np.testing.assert_allclose(summed, expected, rtol=1e-12)
+
+    def test_empty_locations_gives_zeros(self, efg_dir):
+        from qdot.nmr import absorption_map
+
+        result = absorption_map(
+            _SPECIES, _SMALL_FIELDS, "Faraday", _RF_FREQS, [], efg_dir, _BOUNDS
+        )
+        assert np.all(result == 0)
+
+    def test_invalid_species_raises(self, efg_dir):
+        from qdot.nmr import absorption_map
+
+        with pytest.raises(ValueError, match="nuclear_species"):
+            absorption_map(
+                "Fe56", _SMALL_FIELDS, "Faraday", _RF_FREQS, _LOCS, efg_dir, _BOUNDS
+            )
+
+    def test_nonnegative(self, efg_dir):
+        from qdot.nmr import absorption_map
+
+        result = absorption_map(
+            _SPECIES,
+            _SMALL_FIELDS,
+            "Faraday",
+            _RF_FREQS,
+            _LOCS,
+            efg_dir,
+            _BOUNDS,
+            processes=2,
+        )
+        assert np.all(result >= 0)
+
+
+# ---------------------------------------------------------------------------
+# Combined spectrum and experimental simulation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def all_species_dir(tmp_path):
+    """EFG archives for all four species plus a concentration file."""
+    rng = np.random.default_rng(11)
+    for species in ("Ga69", "Ga71", "As75", "In115"):
+        eta = rng.uniform(0.3, 0.7, _SHAPE)
+        V_XX = rng.uniform(-5e20, 5e20, _SHAPE)
+        V_YY = rng.uniform(-5e20, 5e20, _SHAPE)
+        V_ZZ = rng.uniform(1e20, 5e20, _SHAPE)
+        euler = rng.uniform(0, 2 * np.pi, (*_SHAPE, 3))
+        save_efg(tmp_path, species, _BOUNDS, 1, eta, V_XX, V_YY, V_ZZ, euler)
+    # Concentration file covering the bounds; mean ~0.25.
+    conc = rng.uniform(0.2, 0.3, (4, 4))
+    np.save(tmp_path / "conc_data_to_scale_cubic_interpolation.npy", conc)
+    return tmp_path
+
+
+class TestCombinedSpectrum:
+    def test_normalised_to_one(self, all_species_dir):
+        from qdot.nmr import combined_spectrum
+
+        result = combined_spectrum(
+            1.0, "Faraday", _RF_FREQS, _LOCS, all_species_dir, _BOUNDS, processes=2
+        )
+        assert result.shape == (len(_RF_FREQS),)
+        assert np.isclose(np.max(result), 1.0)
+        assert np.all(result >= 0)
+
+
+class TestExperimentalNmrSimulation:
+    def test_returns_three_species_maps(self, all_species_dir):
+        from qdot.nmr import experimental_nmr_simulation
+
+        maps = experimental_nmr_simulation(
+            "Faraday",
+            _SMALL_FIELDS,
+            _RF_FREQS,
+            n_locations=4,
+            data_dir=all_species_dir,
+            region_bounds=_BOUNDS,
+            rng=5,
+            processes=2,
+        )
+        assert set(maps) == {"In115", "Ga69", "As75"}
+        for data in maps.values():
+            assert data.shape == (len(_SMALL_FIELDS), len(_RF_FREQS))
+            assert np.all(data >= 0)
+
+    def test_too_few_locations_raises(self, all_species_dir):
+        from qdot.nmr import experimental_nmr_simulation
+
+        with pytest.raises(ValueError, match="too small"):
+            experimental_nmr_simulation(
+                "Faraday",
+                _SMALL_FIELDS,
+                _RF_FREQS,
+                n_locations=1,
+                data_dir=all_species_dir,
+                region_bounds=_BOUNDS,
+            )
+
+
+# ---------------------------------------------------------------------------
+# RF pulse selectivity
+# ---------------------------------------------------------------------------
+
+
+class TestLorentzianPulse:
+    def test_peak_at_centre(self):
+        from qdot.nmr import lorentzian_pulse
+
+        freqs = np.linspace(0, 100, 1001)
+        pulse = lorentzian_pulse(freqs, centre=40.0, width=5.0)
+        assert freqs[np.argmax(pulse)] == pytest.approx(40.0, abs=0.1)
+
+    def test_unit_area(self):
+        from qdot.nmr import lorentzian_pulse
+        from scipy.integrate import simpson
+
+        # Wide grid so the Cauchy tails are mostly captured.
+        freqs = np.linspace(-1000, 1000, 200001)
+        pulse = lorentzian_pulse(freqs, centre=0.0, width=2.0)
+        assert simpson(pulse, x=freqs) == pytest.approx(1.0, abs=1e-2)
+
+
+class TestPulseCaptureFraction:
+    def test_wide_pulse_captures_everything(self):
+        from qdot.nmr import pulse_capture_fraction
+
+        freqs = np.linspace(0, 100, 2001)
+        spectrum = np.exp(-((freqs - 50) ** 2) / 4)
+        frac = pulse_capture_fraction(spectrum, freqs, 50.0, 1e6)
+        assert frac == pytest.approx(1.0, abs=1e-3)
+
+    def test_offresonant_narrow_pulse_captures_little(self):
+        from qdot.nmr import pulse_capture_fraction
+
+        freqs = np.linspace(0, 100, 2001)
+        spectrum = np.exp(-((freqs - 50) ** 2) / 4)
+        frac = pulse_capture_fraction(spectrum, freqs, 5.0, 0.5)
+        assert frac < 0.05
+
+    def test_window_restricts_integral(self):
+        from qdot.nmr import pulse_capture_fraction
+
+        freqs = np.linspace(0, 100, 2001)
+        # Two identical peaks; pulse on the first one.
+        spectrum = np.exp(-((freqs - 30) ** 2) / 4) + np.exp(-((freqs - 70) ** 2) / 4)
+        in_band = pulse_capture_fraction(
+            spectrum, freqs, 30.0, 1e6, window=(20.0, 40.0)
+        )
+        overall = pulse_capture_fraction(spectrum, freqs, 30.0, 20.0)
+        assert in_band == pytest.approx(1.0, abs=1e-3)
+        assert overall < in_band

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,208 @@
+"""
+Smoke tests for qdot.plot: every function renders synthetic data and saves a
+non-empty file. Figure content is not asserted — these catch API breakage,
+exceptions, and backend issues only.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pytest
+
+from qdot import plot
+
+_FIELDS = np.linspace(0.1, 2.0, 4)
+_FREQS = np.linspace(1e6, 50e6, 8)
+
+
+def _saved(tmp_path, name):
+    path = tmp_path / name
+    assert path.exists() and path.stat().st_size > 0
+    return path
+
+
+@pytest.fixture
+def nmr_map():
+    rng = np.random.default_rng(0)
+    return rng.uniform(0.1, 1.0, (len(_FIELDS), len(_FREQS)))
+
+
+class TestNmrMapPlots:
+    def test_plot_nmr_map(self, tmp_path, nmr_map):
+        plot.plot_nmr_map(
+            nmr_map, _FIELDS, _FREQS, title="t", save_path=tmp_path / "m.png"
+        )
+        _saved(tmp_path, "m.png")
+
+    def test_plot_nmr_map_linear_scale(self, tmp_path, nmr_map):
+        plot.plot_nmr_map(
+            nmr_map, _FIELDS, _FREQS, log_scale=False, save_path=tmp_path / "m.png"
+        )
+        _saved(tmp_path, "m.png")
+
+    def test_plot_nmr_map_pair(self, tmp_path, nmr_map):
+        plot.plot_nmr_map_pair(
+            nmr_map,
+            nmr_map * 2,
+            ("Faraday", "Voigt"),
+            _FIELDS,
+            _FREQS,
+            save_path=tmp_path / "p.png",
+        )
+        _saved(tmp_path, "p.png")
+
+    def test_plot_nmr_map_difference(self, tmp_path, nmr_map):
+        plot.plot_nmr_map_difference(
+            nmr_map, nmr_map * 2, _FIELDS, _FREQS, save_path=tmp_path / "d.png"
+        )
+        _saved(tmp_path, "d.png")
+
+    def test_plot_nmr_map_layered(self, tmp_path, nmr_map):
+        plot.plot_nmr_map_layered(
+            {"In115": nmr_map, "Ga69": nmr_map * 2, "As75": nmr_map * 3},
+            _FIELDS,
+            _FREQS,
+            save_path=tmp_path / "l.png",
+        )
+        _saved(tmp_path, "l.png")
+
+
+class TestEnergyLevelPlots:
+    def test_plot_energy_levels(self, tmp_path):
+        sweep = np.linspace(0, 3, 10)
+        levels = np.outer([-1.5, -0.5, 0.5, 1.5], sweep) * 1e7
+        plot.plot_energy_levels(
+            sweep, levels, "Applied B Field (T)", save_path=tmp_path / "el.png"
+        )
+        _saved(tmp_path, "el.png")
+
+    def test_plot_energy_levels_comparison(self, tmp_path):
+        sweep = np.linspace(0, 3, 10)
+        levels = np.outer([-1.5, -0.5, 0.5, 1.5], sweep) * 1e7
+        plot.plot_energy_levels_comparison(
+            sweep, levels, levels * 0.8, save_path=tmp_path / "elc.png"
+        )
+        _saved(tmp_path, "elc.png")
+
+
+class TestSiteMapPlots:
+    def test_plot_site_map(self, tmp_path):
+        plot.plot_site_map(
+            np.random.default_rng(0).random((5, 5)),
+            colorbar_label="x",
+            title="t",
+            save_path=tmp_path / "s.png",
+        )
+        _saved(tmp_path, "s.png")
+
+    def test_plot_biaxiality(self, tmp_path):
+        plot.plot_biaxiality(
+            np.random.default_rng(0).random((5, 5)), save_path=tmp_path / "b.png"
+        )
+        _saved(tmp_path, "b.png")
+
+    def test_plot_quadrupole_frequency(self, tmp_path):
+        plot.plot_quadrupole_frequency(
+            np.random.default_rng(0).random((5, 5)) * 1e6,
+            save_path=tmp_path / "q.png",
+        )
+        _saved(tmp_path, "q.png")
+
+    def test_plot_efg_directions(self, tmp_path):
+        rng = np.random.default_rng(0)
+        euler = rng.uniform(0, np.pi, (6, 6, 3))
+        background = rng.random((6, 6))
+        plot.plot_efg_directions(
+            euler,
+            background,
+            background_label="η",
+            spacing=2,
+            save_path=tmp_path / "e.png",
+        )
+        _saved(tmp_path, "e.png")
+
+    def test_plot_efg_directions_with_lengths(self, tmp_path):
+        rng = np.random.default_rng(0)
+        plot.plot_efg_directions(
+            rng.uniform(0, np.pi, (6, 6, 3)),
+            rng.random((6, 6)),
+            arrow_lengths=rng.random((6, 6)),
+            spacing=2,
+            double_headed=False,
+            save_path=tmp_path / "e2.png",
+        )
+        _saved(tmp_path, "e2.png")
+
+
+class TestHistogramPlots:
+    @pytest.mark.parametrize("fit", [None, "gauss", "maxwell", "gamma"])
+    def test_plot_frequency_histogram_fits(self, tmp_path, fit):
+        rng = np.random.default_rng(0)
+        freqs = rng.normal(0, 0.3, 2000) * 1e6
+        plot.plot_frequency_histogram(
+            freqs, fit=fit, label="Ga69", save_path=tmp_path / "h.png"
+        )
+        _saved(tmp_path, "h.png")
+
+    def test_invalid_fit_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="fit"):
+            plot.plot_frequency_histogram(
+                np.random.default_rng(0).normal(0, 0.3, 500) * 1e6,
+                fit="lorentz",
+                save_path=tmp_path / "h.png",
+            )
+
+    def test_plot_frequency_histograms_overlay(self, tmp_path):
+        rng = np.random.default_rng(0)
+        sets = {s: rng.normal(0, 0.3, 500) * 1e6 for s in ("Ga69", "As75")}
+        plot.plot_frequency_histograms(sets, save_path=tmp_path / "ho.png")
+        _saved(tmp_path, "ho.png")
+
+    def test_plot_frequency_histograms_grid(self, tmp_path):
+        rng = np.random.default_rng(0)
+        sets = {
+            s: rng.normal(0, 0.3, 800) * 1e6 for s in ("Ga69", "Ga71", "As75", "In115")
+        }
+        plot.plot_frequency_histograms_grid(
+            sets, fit="gamma", save_path=tmp_path / "hg.png"
+        )
+        _saved(tmp_path, "hg.png")
+
+
+class TestStrainPlots:
+    @pytest.mark.parametrize("layout", ["horizontal", "vertical"])
+    def test_plot_measured_strain(self, tmp_path, layout):
+        rng = np.random.default_rng(0)
+        xx, xz, zz = (rng.uniform(-0.02, 0.02, (8, 8)) for _ in range(3))
+        plot.plot_measured_strain(
+            xx, xz, zz, layout=layout, save_path=tmp_path / "ms.png"
+        )
+        _saved(tmp_path, "ms.png")
+
+    def test_invalid_layout_raises(self):
+        arr = np.zeros((4, 4))
+        with pytest.raises(ValueError, match="layout"):
+            plot.plot_measured_strain(arr, arr, arr, layout="diagonal")
+
+    def test_plot_strain_row_cut(self, tmp_path):
+        rng = np.random.default_rng(0)
+        xx, xz, zz = (rng.uniform(-0.02, 0.02, (8, 8)) for _ in range(3))
+        plot.plot_strain_row_cut(xx, xz, zz, row=3, save_path=tmp_path / "rc.png")
+        _saved(tmp_path, "rc.png")
+
+
+class TestCurvePlots:
+    def test_plot_polarisation_curve(self, tmp_path):
+        deph = np.linspace(1, 0.5, 20)
+        plot.plot_polarisation_curve(
+            deph, np.cos(deph), reference=0.9, save_path=tmp_path / "pc.png"
+        )
+        _saved(tmp_path, "pc.png")
+
+    def test_plot_fidelity_curves(self, tmp_path):
+        strengths = np.linspace(0, 1, 10)
+        curves = {"1 photon": 1 - 0.2 * strengths, "2 photons": 1 - 0.4 * strengths}
+        plot.plot_fidelity_curves(strengths, curves, save_path=tmp_path / "f.png")
+        _saved(tmp_path, "f.png")

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,0 +1,60 @@
+import numpy as np
+
+from qdot.sites import all_locations, random_locations, find_best_locations
+
+
+class TestAllLocations:
+    def test_count_and_contents(self):
+        locs = all_locations((2, 3))
+        assert len(locs) == 6
+        assert locs == [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]
+
+
+class TestRandomLocations:
+    def test_count(self):
+        assert len(random_locations(10, (4, 5), rng=0)) == 10
+
+    def test_within_bounds(self):
+        locs = random_locations(200, (4, 5), rng=0)
+        rows = [r for r, _ in locs]
+        cols = [c for _, c in locs]
+        assert min(rows) >= 0 and max(rows) < 4
+        assert min(cols) >= 0 and max(cols) < 5
+
+    def test_seed_reproducible(self):
+        assert random_locations(20, (10, 10), rng=42) == random_locations(
+            20, (10, 10), rng=42
+        )
+
+
+class TestFindBestLocations:
+    def test_all_seeds_snap_to_global_peak(self):
+        # One strong peak; with a window covering the whole array every seed
+        # must snap to it.
+        xx = np.zeros((10, 10))
+        xx[5, 5] = 1.0
+        xz = np.zeros((10, 10))
+        zz = np.zeros((10, 10))
+
+        locs = find_best_locations(8, xx, xz, zz, search_range=10, rng=1)
+        assert all(loc == (5, 5) for loc in locs)
+
+    def test_boundary_peak_found_with_clipped_window(self):
+        # Peak in the corner: window clipping must not shift the result.
+        xx = np.zeros((6, 6))
+        xx[0, 0] = 1.0
+
+        locs = find_best_locations(5, xx, xx, xx, search_range=20, rng=2)
+        assert all(loc == (0, 0) for loc in locs)
+
+    def test_metric_is_component_sum(self):
+        # Peaks in different components at different sites; the sum decides.
+        xx = np.zeros((8, 8))
+        xz = np.zeros((8, 8))
+        zz = np.zeros((8, 8))
+        xx[2, 2] = 0.4
+        xz[2, 2] = 0.4  # combined 0.8 at (2, 2)
+        zz[6, 6] = 0.7  # only 0.7 at (6, 6)
+
+        locs = find_best_locations(5, xx, xz, zz, search_range=10, rng=3)
+        assert all(loc == (2, 2) for loc in locs)


### PR DESCRIPTION
Implements the porting plan from the expanded archive gap analysis (included here as the first commit), bringing the archive's experimental simulation and graph-generation capabilities into the `qdot` package. Every algorithm was ported from a direct read of the original scripts.

## New capabilities

**NMR** (`qdot/nmr.py`)
- `absorption_map` / `summed_absorption_spectrum` — multi-site parallel engine (Pool over sites per field; EFG archive loaded once per map). The single-site path shares the same core, and a test asserts the engine equals the sum of single-site spectra exactly.
- `experimental_nmr_simulation` — concentration-weighted In/Ga/As population split, returning per-species maps for summed or layered rendering.
- `combined_spectrum`, `lorentzian_pulse`, `pulse_capture_fraction` — all-species spectrum and RF pulse selectivity analysis (hardcoded archive frequency windows became arguments).
- `real_strain`/`mirror_type` now pass through to `load_efg`, unblocking mirrored-dot NMR.

**Hamiltonians** — `energy_levels_vs_field` / `energy_levels_vs_eta` sweeps for anti-crossing diagrams.

**EFG / isotopes** — `quadrupole_coupling` factored out of two modules; `quadrupole_frequency` and `equivalent_b_field` (the computation the existing plotters lacked).

**IO** — `SOKOLOV_REGIONS` named-region catalogue, `region_from_rectangle`, `mirror_array` + mirrored strain/concentration dataset creation, the missing mirrored-concentration loader, `save_nmr_map`/`load_nmr_map` parameter-keyed cache, `load_correlator_archive`.

**Sites** (new `qdot/sites.py`) — `all_locations`, `random_locations`, `find_best_locations` (strain-maximum snap).

**Machine gun** — density-matrix protocol with dephasing and amplitude-damping channels, `fidelity_vs_error` / `trace_distance_vs_error` sweeps, `error_list_to_array`.

**NFF** — x/y polarisation expectations and `dephasing_from_scattering`.

**Plotting** (`qdot/plot.py`) — NMR maps (single, pair, difference, layered), energy level diagrams, generic site maps + biaxiality/quadrupole-frequency wrappers, EFG quiver overlays, frequency histograms with Gaussian/Maxwell/gamma fits, measured Sokolov strain panels, strain row cuts, NFF polarisation curve, fidelity curves.

## Deliberate deviations from the archive (documented in code)
- `find_best_locations` corrects the archive's window-offset slip when the search window clips at array boundaries (corner-peak test included).
- The noisy machine gun applies the trailing error channel uniformly for both channels; the archive did so only for dephasing.
- Ga71 exclusion and the 50%-As heuristic in the experimental simulation are kept faithful but parameterised.

## Physics review requested
Four questions added to `human-todo.`: the species-population heuristic (incl. Ga71's exclusion), the ε-sum metric in `find_best_locations`, which histogram distribution fits are meaningful, and the NFF x/y-polarisation basis convention.

## Runner
`run_new_experiments.py` drives everything against `real_data/` (reusing the existing step-1 EFG archives) and writes figures to `new_data_outputs/`, which is gitignored — no generated graphics are included in this PR. A full run takes ~25 s at the default resolution and was verified against the real dataset: the Ga69 ridge follows the 10.2 MHz/T Zeeman slope, In115 shows the ten-level anti-crossing fan, and the combined 3 T spectrum peaks at the In115/Ga69/Ga71 central transitions.

## Testing
227 tests pass (88 new): engine-vs-single-site equivalence, density-matrix machine gun pinned to the state-vector path, trace preservation, pure-Zeeman linearity, mirrored dataset and NMR cache round trips, boundary-clipped site search, and render smoke tests for every plot function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)